### PR TITLE
Skip override

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,26 @@ app.use(function first (s1, opts, cb) {
   }
 })
 ```
+<a name="skip-override"></a>
+#### Skip override
+If for some reason you have set an override and you want to skip it for a *specific function*, you must add `functionName[Symbol.for('skip-override')] = true` to your code.  
+Example:
+```js
+const server = { my: 'server' }
+const app = boot(server)
 
+app.override = function (s) {
+  return Object.create(s)
+}
+
+first[Symbol.for('skip-override')] = true
+app.use(first)
+
+function first (s, opts, cb) {
+  // some code
+  cb()
+}
+```
 -------------------------------------------------------
 
 ## Acknowledgements

--- a/boot.js
+++ b/boot.js
@@ -173,6 +173,7 @@ function Plugin (parent, func, opts, callback) {
   this.deferred = false
   this.onFinish = null
   this.parent = parent
+  this.skipOverride = !!opts.skipOverride
 
   this.q = fastq(parent, loadPlugin, 1)
   this.q.pause()
@@ -186,7 +187,7 @@ function Plugin (parent, func, opts, callback) {
 
 Plugin.prototype.exec = function (server, cb) {
   const func = this.func
-  this.server = this.parent.override(server)
+  this.server = this.skipOverride ? server : this.parent.override(server)
   func(this.server, this.opts, cb)
 }
 

--- a/boot.js
+++ b/boot.js
@@ -173,7 +173,7 @@ function Plugin (parent, func, opts, callback) {
   this.deferred = false
   this.onFinish = null
   this.parent = parent
-  this.skipOverride = !!opts.skipOverride
+  this.skipOverride = !!func[Symbol.for('skip-override')]
 
   this.q = fastq(parent, loadPlugin, 1)
   this.q.pause()

--- a/test/override.js
+++ b/test/override.js
@@ -140,3 +140,20 @@ test('fastify test case', (t) => {
     t.notOk(instance.test)
   })
 })
+
+test('skip override', (t) => {
+  t.plan(2)
+
+  const server = { my: 'server' }
+  const app = boot(server)
+
+  app.override = function (s) {
+    return Object.create(s)
+  }
+
+  app.use(function first (s, opts, cb) {
+    t.equal(s, server)
+    t.notOk(server.isPrototypeOf(s))
+    cb()
+  }, { skipOverride: true })
+})

--- a/test/override.js
+++ b/test/override.js
@@ -151,9 +151,12 @@ test('skip override', (t) => {
     return Object.create(s)
   }
 
-  app.use(function first (s, opts, cb) {
+  first[Symbol.for('skip-override')] = true
+  app.use(first)
+
+  function first (s, opts, cb) {
     t.equal(s, server)
     t.notOk(server.isPrototypeOf(s))
     cb()
-  }, { skipOverride: true })
+  }
 })


### PR DESCRIPTION
In the previous PR (#9) we added the ovverride support to create a plugin inheritance chain.
Sometimes, for some reason, the user needs to disable the override if he has set one.

With this PR we support that.

Example:
```js
const server = { my: 'server' }
const app = boot(server)

app.override = function (s) {
  return Object.create(s)
}

first[Symbol.for('skip-override')] = true
app.use(first)

function first (s, opts, cb) {
  // some code
  cb()
}
```

If this is 👍  for you, I can proceed to update the docs.