### PR TITLE
Updated override and after/ready callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,13 +148,24 @@ The functions will be loaded in the same order as they are inside the array.
 -------------------------------------------------------
 <a name="after"></a>
 
-### app.after(func([done]), [cb])
+### app.after(func([context], [done]), [cb])
 
-Calls a functon after all the previously defined plugins are loaded, including
-all their dependencies. The `'start'` event is not emitted yet.
+Calls a function after all the previously defined plugins are loaded, including
+all their dependencies. The `'start'` event is not emitted yet.  
+If one parameter is given to the callback, that parameter will be the `done` callback.  
+If two parameters are given to the callback, the first will be the `contenxt`, the second will be the `done` callback.
 
 ```js
+const server = {}
+...
+// after with one parameter
 boot.after(function (done) {
+  done()
+})
+
+// after with two parameters
+boot.after(function (context, done) {
+  assert.equal(context, server)
   done()
 })
 ```
@@ -167,14 +178,24 @@ chainable API.
 -------------------------------------------------------
 <a name="ready"></a>
 
-### app.ready(func([done]))
+### app.ready(func([context], [done]))
 
 Calls a functon after all the plugins and `after` call are
 completed, but befer `'start'` is emitted. `ready` callbacks are
-executed one at a time.
-
+executed one at a time.  
+If one parameter is given to the callback, that parameter will be the `done` callback.  
+If two parameters are given to the callback, the first will be the `contenxt`, the second will be the `done` callback.
 ```js
+const server = {}
+...
+// ready with one parameter
 boot.ready(function (done) {
+  done()
+})
+
+// ready with two parameters
+boot.ready(function (context, done) {
+  assert.equal(context, server)
   done()
 })
 ```
@@ -204,11 +225,12 @@ boot(app, {
 -------------------------------------------------------
 <a name="override"></a>
 
-### app.override(server)
+### app.override(server, plugin)
 
 Allows to override the instance of the server for each loading
 plugin. It allows the creation of an inheritance chain for the
-server instances.
+server instances.  
+The first parameter is the server instance and the second is the plugin function.
 
 ```js
 const boot = require('avvio')
@@ -218,7 +240,7 @@ const app = boot(server)
 
 console.log(app !== server, 'override must be set on the Avvio instance')
 
-app.override = function (s) {
+app.override = function (s, fn) {
   // create a new instance with the
   // server as the prototype
   const res = Object.create(s)
@@ -240,26 +262,6 @@ app.use(function first (s1, opts, cb) {
     cb()
   }
 })
-```
-<a name="skip-override"></a>
-#### Skip override
-If for some reason you have set an override and you want to skip it for a *specific function*, you must add `functionName[Symbol.for('skip-override')] = true` to your code.  
-Example:
-```js
-const server = { my: 'server' }
-const app = boot(server)
-
-app.override = function (s) {
-  return Object.create(s)
-}
-
-first[Symbol.for('skip-override')] = true
-app.use(first)
-
-function first (s, opts, cb) {
-  // some code
-  cb()
-}
 ```
 -------------------------------------------------------
 

--- a/boot.js
+++ b/boot.js
@@ -174,7 +174,6 @@ function Plugin (parent, func, opts, callback) {
   this.deferred = false
   this.onFinish = null
   this.parent = parent
-  this.skipOverride = !!func[Symbol.for('skip-override')]
 
   this.q = fastq(parent, loadPlugin, 1)
   this.q.pause()
@@ -188,7 +187,7 @@ function Plugin (parent, func, opts, callback) {
 
 Plugin.prototype.exec = function (server, cb) {
   const func = this.func
-  this.server = this.skipOverride ? server : this.parent.override(server, func)
+  this.server = this.parent.override(server, func)
   func(this.server, this.opts, cb)
 }
 

--- a/boot.js
+++ b/boot.js
@@ -71,9 +71,6 @@ function Boot (server, opts, done) {
     this.once('start', done)
   }
 
-  /* function readyQIterator (func, cb) {
-    callWithCbOrNextTick(func, cb, server)
-  } */
   this._readyQ = fastq(this, callWithCbOrNextTick, 1)
   this._readyQ.pause()
   this._readyQ.drain = () => {

--- a/test/after-and-ready.js
+++ b/test/after-and-ready.js
@@ -166,3 +166,24 @@ test('ready adds at the end of the queue', (t) => {
     t.ok(readyCalled, 'ready called')
   })
 })
+
+test('if the after/ready callback has two parameters, the first one must be the context', (t) => {
+  t.plan(2)
+
+  const server = { my: 'server' }
+  const app = boot(server)
+
+  app.use(function (s, opts, done) {
+    done()
+  })
+
+  app.after(function (context, cb) {
+    t.equal(server, context)
+    cb()
+  })
+
+  app.ready(function (context, cb) {
+    t.equal(server, context)
+    cb()
+  })
+})

--- a/test/override.js
+++ b/test/override.js
@@ -160,3 +160,23 @@ test('skip override', (t) => {
     cb()
   }
 })
+
+test('override should pass also the plugin function', (t) => {
+  t.plan(3)
+
+  const server = { my: 'server' }
+  const app = boot(server)
+
+  app.override = function (s, fn) {
+    t.type(fn, 'function')
+    t.equal(fn, first)
+    return s
+  }
+
+  app.use(first)
+
+  function first (s, opts, cb) {
+    t.equal(s, server)
+    cb()
+  }
+})

--- a/test/override.js
+++ b/test/override.js
@@ -141,26 +141,6 @@ test('fastify test case', (t) => {
   })
 })
 
-test('skip override', (t) => {
-  t.plan(2)
-
-  const server = { my: 'server' }
-  const app = boot(server)
-
-  app.override = function (s) {
-    return Object.create(s)
-  }
-
-  first[Symbol.for('skip-override')] = true
-  app.use(first)
-
-  function first (s, opts, cb) {
-    t.equal(s, server)
-    t.notOk(server.isPrototypeOf(s))
-    cb()
-  }
-})
-
 test('override should pass also the plugin function', (t) => {
   t.plan(3)
 
@@ -177,6 +157,29 @@ test('override should pass also the plugin function', (t) => {
 
   function first (s, opts, cb) {
     t.equal(s, server)
+    cb()
+  }
+})
+
+test('skip override - fastify test case', (t) => {
+  t.plan(2)
+
+  const server = { my: 'server' }
+  const app = boot(server)
+
+  app.override = function (s, func) {
+    if (func[Symbol.for('skip-override')]) {
+      return s
+    }
+    return Object.create(s)
+  }
+
+  first[Symbol.for('skip-override')] = true
+  app.use(first)
+
+  function first (s, opts, cb) {
+    t.equal(s, server)
+    t.notOk(server.isPrototypeOf(s))
     cb()
   }
 })


### PR DESCRIPTION
- `override` takes as second parameter the plugin function
- if `after`/`ready` have two parameters, the first one is the context (this to avoid breaking changes) #6 