### PR TITLE
Close queue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,13 @@
 language: node_js
+
 node_js:
-  - "4"
+  - "8"
+  - "7"
   - "6"
+  - "5"
+  - "4"
+
+notifications:
+  email:
+    on_success: never
+    on_failure: always

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ function third (instance, opts, cb) {
   * <a href="#after"><code>instance.<b>after()</b></code></a>
   * <a href="#ready"><code>instance.<b>ready()</b></code></a>
   * <a href="#override"><code>instance.<b>override()</b></code></a>
+  * <a href="#onClose"><code>instance.<b>onClose()</b></code></a>
+  * <a href="#close"><code>instance.<b>close()</b></code></a>
   * <a href="#express"><code>avvio.<b>express()</b></code></a>
 
 -------------------------------------------------------
@@ -224,7 +226,7 @@ Returns the instance on which `after` is called, to support a chainable API.
 
 ### app.ready(func(error, [context], [done]))
 
-Calls a functon after all the plugins and `after` call are completed, but before `'start'` is emitted. `ready` callbacks are executed one at a time.  
+Calls a function after all the plugins and `after` call are completed, but before `'start'` is emitted. `ready` callbacks are executed one at a time.  
 
 The callback changes basing on the parameters your are giving:
 1. If one parameter is given to the callback, that parameter will be the `error` object.  
@@ -314,6 +316,79 @@ app.use(function first (s1, opts, cb) {
   }
 })
 ```
+-------------------------------------------------------
+
+<a name="onClose"></a>
+### app.onClose(func(error, [context], [done]))
+
+Registers a new callback that will be fired once then `close` api is called.
+
+The callback changes basing on the parameters your are giving:
+1. If one parameter is given to the callback, that parameter will be the `error` object.  
+2. If two parameters are given to the callback, the first will be the `error` object, the second will be the `done` callback.  
+3. If three parameters are given to the callback, the first will be the `error` object, the second will be the `context` and the third the `done` callback.
+
+```js
+const server = {}
+...
+// onClose with one parameter
+boot.onClose(function (err) {
+  if (err) throw err
+})
+
+// onClose with two parameter
+boot.onClose(function (err, done) {
+  if (err) throw err
+  done()
+})
+
+// onClose with three parameters
+boot.onClose(function (err, context, done) {
+  if (err) throw err
+  assert.equal(context, server)
+  done()
+})
+```
+
+`done` must be called only once.
+Returns the instance on which `onClose` is called, to support a chainable API.
+
+-------------------------------------------------------
+
+<a name="close"></a>
+### app.close(func(error, [context], [done]))
+
+Starts the shotdown procedure, the callback is called once all the registered callbacks with `onClose` has been executed.
+
+The callback changes basing on the parameters your are giving:
+1. If one parameter is given to the callback, that parameter will be the `error` object.  
+2. If two parameters are given to the callback, the first will be the `error` object, the second will be the `done` callback.  
+3. If three parameters are given to the callback, the first will be the `error` object, the second will be the `context` and the third the `done` callback.
+
+```js
+const server = {}
+...
+// close with one parameter
+boot.close(function (err) {
+  if (err) throw err
+})
+
+// close with two parameter
+boot.close(function (err, done) {
+  if (err) throw err
+  done()
+})
+
+// close with three parameters
+boot.close(function (err, context, done) {
+  if (err) throw err
+  assert.equal(context, server)
+  done()
+})
+```
+
+`done` must be called only once.
+
 -------------------------------------------------------
 
 ## Acknowledgements

--- a/boot.js
+++ b/boot.js
@@ -171,7 +171,7 @@ Boot.prototype.after = function (func, cb) {
 }
 
 Boot.prototype.onClose = function (func) {
-  this._closeQ.push(func, err => {
+  this._closeQ.unshift(func, err => {
     if (err) this._error = err
   })
   return this

--- a/boot.js
+++ b/boot.js
@@ -10,6 +10,8 @@ function wrap (server, opts, instance) {
   const useKey = expose.use || 'use'
   const afterKey = expose.after || 'after'
   const readyKey = expose.ready || 'ready'
+  const onCloseKey = expose.onClose || 'onClose'
+  const closeKey = expose.close || 'close'
 
   if (server[useKey]) {
     throw new Error(useKey + '() is already defined, specify an expose option')
@@ -34,7 +36,17 @@ function wrap (server, opts, instance) {
   }
 
   server[readyKey] = function (cb) {
-    instance.after(cb)
+    instance.ready(cb)
+    return this
+  }
+
+  server[onCloseKey] = function (cb) {
+    instance.onClose(cb)
+    return this
+  }
+
+  server[closeKey] = function (cb) {
+    instance.close(cb)
     return this
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,12 +30,12 @@
   },
   "homepage": "https://github.com/mcollina/avvio#readme",
   "devDependencies": {
-    "express": "^4.14.0",
-    "pre-commit": "^1.1.3",
-    "standard": "^10.0.0",
-    "tap": "^10.0.0"
+    "express": "^4.15.3",
+    "pre-commit": "^1.2.2",
+    "standard": "^10.0.2",
+    "tap": "^10.7.0"
   },
   "dependencies": {
-    "fastq": "^1.4.1"
+    "fastq": "^1.5.0"
   }
 }

--- a/plugin.js
+++ b/plugin.js
@@ -1,0 +1,62 @@
+'use strict'
+
+const fastq = require('fastq')
+
+function Plugin (parent, func, opts, callback) {
+  this.func = func
+  this.opts = opts
+  this.callback = callback
+  this.deferred = false
+  this.onFinish = null
+  this.parent = parent
+
+  this.q = fastq(parent, loadPlugin, 1)
+  this.q.pause()
+
+  // always start the queue in the next tick
+  // because we try to attach subsequent call to use()
+  // to the right plugin. we need to defer them,
+  // or they will end up at the top of _current
+  process.nextTick(this.q.resume.bind(this.q))
+}
+
+Plugin.prototype.exec = function (server, cb) {
+  const func = this.func
+  this.server = this.parent.override(server, func, this.opts)
+  func(this.server, this.opts, cb)
+}
+
+Plugin.prototype.finish = function (err, cb) {
+  const callback = this.callback
+  // if 'use' has a callback
+  if (callback) {
+    callback(err)
+    // if 'use' has a callback but does not have parameters
+    cb(callback.length > 0 ? null : err)
+  } else {
+    cb(err)
+  }
+}
+
+// loads a plugin
+function loadPlugin (toLoad, cb) {
+  const last = this._current[0]
+  // place the plugin at the top of _current
+  this._current.unshift(toLoad)
+  toLoad.exec((last && last.server) || this._server, (err) => {
+    if (err || !(toLoad.q.length() > 0 || toLoad.q.running() > 0)) {
+      // finish now, because there is nothing left to do
+      this._current.shift()
+      toLoad.finish(err, cb)
+    } else {
+      // finish when the queue of nested plugins to load is empty
+      toLoad.q.drain = () => {
+        this._current.shift()
+        toLoad.finish(null, cb)
+      }
+    }
+  })
+}
+
+module.exports = Plugin
+module.exports.loadPlugin = loadPlugin

--- a/test/basic.js
+++ b/test/basic.js
@@ -45,7 +45,7 @@ test('boot an app with a plugin and a callback', (t) => {
 })
 
 test('boot a plugin with a custom server', (t) => {
-  t.plan(3)
+  t.plan(4)
 
   const server = {}
   const app = boot(server)
@@ -56,8 +56,43 @@ test('boot a plugin with a custom server', (t) => {
     done()
   })
 
+  app.onClose(() => {
+    t.ok('onClose called')
+  })
+
   app.on('start', () => {
-    t.pass('booted')
+    app.close(() => {
+      t.pass('booted')
+    })
+  })
+})
+
+test('custom instance should inherits avvio methods', (t) => {
+  t.plan(6)
+
+  const server = {}
+  const app = boot(server, {})
+
+  server.use(function (s, opts, done) {
+    t.equal(s, server, 'the first argument is the server')
+    t.deepEqual(opts, {}, 'no options')
+    done()
+  }).after(() => {
+    t.ok('after called')
+  })
+
+  server.onClose(() => {
+    t.ok('onClose called')
+  })
+
+  server.ready(() => {
+    t.ok('ready called')
+  })
+
+  app.on('start', () => {
+    server.close(() => {
+      t.pass('booted')
+    })
   })
 })
 

--- a/test/close.js
+++ b/test/close.js
@@ -109,3 +109,37 @@ test('close event', (t) => {
     t.pass('event fired')
   })
 })
+
+test('close order', (t) => {
+  t.plan(5)
+
+  const app = boot()
+  var order = [1, 2, 3, 4]
+
+  app.use(function (server, opts, done) {
+    app.onClose(() => {
+      t.is(order.shift(), 3)
+    })
+
+    app.use(function (server, opts, done) {
+      app.onClose(() => {
+        t.is(order.shift(), 2)
+      })
+      done()
+    }, done)
+  })
+
+  app.use(function (server, opts, done) {
+    app.onClose(() => {
+      t.is(order.shift(), 1)
+    })
+    done()
+  })
+
+  app.on('start', () => {
+    app.close(() => {
+      t.is(order.shift(), 4)
+      t.pass('Closed in the correct order')
+    })
+  })
+})

--- a/test/close.js
+++ b/test/close.js
@@ -1,0 +1,111 @@
+'use strict'
+
+const test = require('tap').test
+const boot = require('..')
+
+test('boot an app with a plugin', (t) => {
+  t.plan(4)
+
+  const app = boot()
+  var last = false
+
+  app.use(function (server, opts, done) {
+    app.onClose(() => {
+      t.ok('onClose called')
+      t.notOk(last)
+      last = true
+    })
+    done()
+  })
+
+  app.on('start', () => {
+    app.close(() => {
+      t.ok(last)
+      t.pass('Closed in the correct order')
+    })
+  })
+})
+
+test('onClose arguments', (t) => {
+  t.plan(3)
+
+  const app = boot()
+
+  app.use(function (server, opts, done) {
+    app.onClose((err, instance, done) => {
+      t.error(err)
+      t.equal(app, instance)
+      done()
+    })
+    done()
+  })
+
+  app.on('start', () => {
+    app.close(() => {
+      t.pass('Closed in the correct order')
+    })
+  })
+})
+
+test('onClose should handle errors', (t) => {
+  t.plan(3)
+
+  const app = boot()
+
+  app.use(function (server, opts, done) {
+    app.onClose((err, instance, done) => {
+      t.error(err)
+      done(new Error('some error'))
+    })
+    done()
+  })
+
+  app.on('start', () => {
+    app.close(err => {
+      t.is(err.message, 'some error')
+      t.pass('Closed in the correct order')
+    })
+  })
+})
+
+test('close arguments', (t) => {
+  t.plan(4)
+
+  const app = boot()
+
+  app.use(function (server, opts, done) {
+    app.onClose((err, instance, done) => {
+      t.error(err)
+      done()
+    })
+    done()
+  })
+
+  app.on('start', () => {
+    app.close((err, instance, done) => {
+      t.error(err)
+      t.equal(instance, app)
+      done()
+      t.pass('Closed in the correct order')
+    })
+  })
+})
+
+test('close event', (t) => {
+  t.plan(3)
+
+  const app = boot()
+  var last = false
+
+  app.on('start', () => {
+    app.close(() => {
+      t.notOk(last)
+      last = true
+    })
+  })
+
+  app.on('close', () => {
+    t.ok(last)
+    t.pass('event fired')
+  })
+})


### PR DESCRIPTION
With this PR we introduce a new queue to handle the shutdown procedure, following the *avvio* style!

- Use `onClose` to add new functions to execute.
- Use `close` to start the process

Related: https://github.com/fastify/fastify/issues/123

Feedbacks?