### PR TITLE
Updated encapsulation handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,9 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# mac files
+.DS_Store
+
+# vim swap files
+*.swp

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ all their dependencies. The `'start'` event is not emitted yet.
 The callback changes basing on the parameters your are giving:
 1. If one parameter is given to the callback, that parameter will be the `error` object.  
 2. If two parameters are given to the callback, the first will be the `error` object, the second will be the `done` callback.  
-3. If three parameters are given to the callback, the first will be the `error` object, the second will be the top level `context` if you didn't provide the server, otherwise an encapsulated `context`, and the third the `done` callback.
+3. If three parameters are given to the callback, the first will be the `error` object, the second will be the top level `context` unless you have specified both server and override, in that case the `context` will be what the override returns, and the third the `done` callback.
 
 ```js
 const server = {}
@@ -231,7 +231,7 @@ Calls a function after all the plugins and `after` call are completed, but befor
 The callback changes basing on the parameters your are giving:
 1. If one parameter is given to the callback, that parameter will be the `error` object.  
 2. If two parameters are given to the callback, the first will be the `error` object, the second will be the `done` callback.  
-3. If three parameters are given to the callback, the first will be the `error` object, the second will be the top level `context` if you didn't provide the server, otherwise an encapsulated `context`, and the third the `done` callback.
+3. If three parameters are given to the callback, the first will be the `error` object, the second will be the top level `context` unless you have specified both server and override, in that case the `context` will be what the override returns, and the third the `done` callback.
 
 ```js
 const server = {}
@@ -325,7 +325,7 @@ Registers a new callback that will be fired once then `close` api is called.
 
 The callback changes basing on the parameters your are giving:
 1. If one parameter is given to the callback, that parameter will be the `context`.  
-2. If two parameters are given to the callback, the first will be the top level `context` if you didn't provide the server, otherwise an encapsulated `context`, the second will be the `done` callback.  
+2. If two parameters are given to the callback, the first will be the top level `context` unless you have specified both server and override, in that case the `context` will be what the override returns, the second will be the `done` callback.  
 
 ```js
 const server = {}
@@ -355,7 +355,7 @@ Starts the shotdown procedure, the callback is called once all the registered ca
 The callback changes basing on the parameters your are giving:
 1. If one parameter is given to the callback, that parameter will be the `error` object.  
 2. If two parameters are given to the callback, the first will be the `error` object, the second will be the `done` callback.  
-3. If three parameters are given to the callback, the first will be the `error` object, the second will be the top level `context` if you didn't provide the server, otherwise an encapsulated `context`, and the third the `done` callback.
+3. If three parameters are given to the callback, the first will be the `error` object, the second will be the top level `context` unless you have specified both server and override, in that case the `context` will be what the override returns, and the third the `done` callback.
 
 ```js
 const server = {}

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ all their dependencies. The `'start'` event is not emitted yet.
 The callback changes basing on the parameters your are giving:
 1. If one parameter is given to the callback, that parameter will be the `error` object.  
 2. If two parameters are given to the callback, the first will be the `error` object, the second will be the `done` callback.  
-3. If three parameters are given to the callback, the first will be the `error` object, the second will be the `context` and the third the `done` callback.
+3. If three parameters are given to the callback, the first will be the `error` object, the second will be the top level `context` if you didn't provide the server, otherwise an encapsulated `context`, and the third the `done` callback.
 
 ```js
 const server = {}
@@ -231,7 +231,7 @@ Calls a function after all the plugins and `after` call are completed, but befor
 The callback changes basing on the parameters your are giving:
 1. If one parameter is given to the callback, that parameter will be the `error` object.  
 2. If two parameters are given to the callback, the first will be the `error` object, the second will be the `done` callback.  
-3. If three parameters are given to the callback, the first will be the `error` object, the second will be the `context` and the third the `done` callback.
+3. If three parameters are given to the callback, the first will be the `error` object, the second will be the top level `context` if you didn't provide the server, otherwise an encapsulated `context`, and the third the `done` callback.
 
 ```js
 const server = {}
@@ -325,7 +325,7 @@ Registers a new callback that will be fired once then `close` api is called.
 
 The callback changes basing on the parameters your are giving:
 1. If one parameter is given to the callback, that parameter will be the `context`.  
-2. If two parameters are given to the callback, the first will be the `context`, the second will be the `done` callback.  
+2. If two parameters are given to the callback, the first will be the top level `context` if you didn't provide the server, otherwise an encapsulated `context`, the second will be the `done` callback.  
 
 ```js
 const server = {}
@@ -355,7 +355,7 @@ Starts the shotdown procedure, the callback is called once all the registered ca
 The callback changes basing on the parameters your are giving:
 1. If one parameter is given to the callback, that parameter will be the `error` object.  
 2. If two parameters are given to the callback, the first will be the `error` object, the second will be the `done` callback.  
-3. If three parameters are given to the callback, the first will be the `error` object, the second will be the `context` and the third the `done` callback.
+3. If three parameters are given to the callback, the first will be the `error` object, the second will be the top level `context` if you didn't provide the server, otherwise an encapsulated `context`, and the third the `done` callback.
 
 ```js
 const server = {}

--- a/boot.js
+++ b/boot.js
@@ -259,7 +259,7 @@ function encapsulateTwoParam (func, that) {
   }
 }
 
-function encapsulateThreeParam (func, that, useContext) {
+function encapsulateThreeParam (func, that) {
   return _encapsulateThreeParam.bind(that)
   function _encapsulateThreeParam (err, cb) {
     if (func.length === 0 || func.length === 1) {

--- a/test/after-and-ready.js
+++ b/test/after-and-ready.js
@@ -343,7 +343,7 @@ test('if `use` has a callback without parameters, the error must reach ready', (
   })
 })
 
-test('shold pass the errors from after to ready', (t) => {
+test('should pass the errors from after to ready', (t) => {
   t.plan(6)
 
   const server = {}
@@ -370,5 +370,111 @@ test('shold pass the errors from after to ready', (t) => {
     server.close(() => {
       t.pass('booted')
     })
+  })
+})
+
+test('after encapsulation', t => {
+  t.plan(4)
+
+  const app = boot()
+  app.override = function (s, fn, opts) {
+    s = Object.create(s)
+    return s
+  }
+
+  app.use(function (instance, opts, next) {
+    instance.test = true
+    instance.after(function (err, i, done) {
+      t.error(err)
+      t.ok(i.test)
+      done()
+    })
+    next()
+  })
+
+  app.after(function (err, i, done) {
+    t.error(err)
+    t.notOk(i.test)
+    done()
+  })
+})
+
+test('ready encapsulation', t => {
+  t.plan(4)
+
+  const app = boot()
+  app.override = function (s, fn, opts) {
+    s = Object.create(s)
+    return s
+  }
+
+  app.use(function (instance, opts, next) {
+    instance.test = true
+    instance.ready(function (err, i, done) {
+      t.error(err)
+      t.ok(i.test)
+      done()
+    })
+    next()
+  })
+
+  app.ready(function (err, i, done) {
+    t.error(err)
+    t.notOk(i.test)
+    done()
+  })
+})
+
+test('after encapsulation with a server', t => {
+  t.plan(4)
+
+  const server = { my: 'server' }
+  const app = boot(server)
+  app.override = function (s, fn, opts) {
+    s = Object.create(s)
+    return s
+  }
+
+  app.use(function (instance, opts, next) {
+    instance.test = true
+    instance.after(function (err, i, done) {
+      t.error(err)
+      t.ok(i.test)
+      done()
+    })
+    next()
+  })
+
+  app.after(function (err, i, done) {
+    t.error(err)
+    t.notOk(i.test)
+    done()
+  })
+})
+
+test('ready encapsulation with a server', t => {
+  t.plan(4)
+
+  const server = { my: 'server' }
+  const app = boot(server)
+  app.override = function (s, fn, opts) {
+    s = Object.create(s)
+    return s
+  }
+
+  app.use(function (instance, opts, next) {
+    instance.test = true
+    instance.ready(function (err, i, done) {
+      t.error(err)
+      t.ok(i.test)
+      done()
+    })
+    next()
+  })
+
+  app.ready(function (err, i, done) {
+    t.error(err)
+    t.notOk(i.test)
+    done()
   })
 })

--- a/test/after-and-ready.js
+++ b/test/after-and-ready.js
@@ -373,7 +373,7 @@ test('should pass the errors from after to ready', (t) => {
   })
 })
 
-test('after encapsulation', t => {
+test('after no encapsulation', t => {
   t.plan(4)
 
   const app = boot()
@@ -386,7 +386,7 @@ test('after encapsulation', t => {
     instance.test = true
     instance.after(function (err, i, done) {
       t.error(err)
-      t.ok(i.test)
+      t.notOk(i.test)
       done()
     })
     next()
@@ -399,7 +399,7 @@ test('after encapsulation', t => {
   })
 })
 
-test('ready encapsulation', t => {
+test('ready no encapsulation', t => {
   t.plan(4)
 
   const app = boot()
@@ -412,7 +412,7 @@ test('ready encapsulation', t => {
     instance.test = true
     instance.ready(function (err, i, done) {
       t.error(err)
-      t.ok(i.test)
+      t.notOk(i.test)
       done()
     })
     next()

--- a/test/close.js
+++ b/test/close.js
@@ -91,7 +91,7 @@ test('onClose arguments - fastify encapsulation test case', (t) => {
   })
 })
 
-test('onClose arguments - encapsulation test case', (t) => {
+test('onClose arguments - encapsulation test case no server', (t) => {
   t.plan(5)
 
   const app = boot()
@@ -104,7 +104,7 @@ test('onClose arguments - encapsulation test case', (t) => {
   app.use(function (instance, opts, next) {
     instance.test = true
     instance.onClose((i, done) => {
-      t.ok(i.test)
+      t.notOk(i.test)
       done()
     })
     next()


### PR DESCRIPTION
We are not passing the correct encapsulated instance when using `override`, this pr aims to fix that.