### PR TITLE
close must receive a function or a falsey value

### DIFF
--- a/boot.js
+++ b/boot.js
@@ -32,21 +32,33 @@ function wrap (server, opts, instance) {
   }
 
   server[afterKey] = function (func) {
+    if (typeof func !== 'function') {
+      throw new Error('not a function')
+    }
     instance.after(encapsulateThreeParam(func, this))
     return this
   }
 
   server[readyKey] = function (func) {
+    if (typeof func !== 'function') {
+      throw new Error('not a function')
+    }
     instance.ready(encapsulateThreeParam(func, this))
     return this
   }
 
   server[onCloseKey] = function (func) {
+    if (typeof func !== 'function') {
+      throw new Error('not a function')
+    }
     instance.onClose(encapsulateTwoParam(func, this))
     return this
   }
 
   server[closeKey] = function (func) {
+    if (func && typeof func !== 'function') {
+      throw new Error('not a function')
+    }
     instance.close(encapsulateThreeParam(func, this))
     return this
   }
@@ -207,6 +219,9 @@ Boot.prototype.onClose = function (func) {
 Boot.prototype.close = function (func) {
   this._error = null
   if (func) {
+    if (func && typeof func !== 'function') {
+      throw new Error('not a function')
+    }
     this._closeQ.push(func)
     this._thereIsCloseCb = true
   }

--- a/boot.js
+++ b/boot.js
@@ -219,7 +219,7 @@ Boot.prototype.onClose = function (func) {
 Boot.prototype.close = function (func) {
   this._error = null
   if (func) {
-    if (func && typeof func !== 'function') {
+    if (typeof func !== 'function') {
       throw new Error('not a function')
     }
     this._closeQ.push(func)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avvio",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Asynchronous bootstrapping of Node applications",
   "main": "boot.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
   },
   "homepage": "https://github.com/mcollina/avvio#readme",
   "devDependencies": {
-    "express": "^4.15.4",
+    "express": "^4.16.2",
     "pre-commit": "^1.2.2",
     "standard": "^10.0.3",
-    "tap": "^10.7.2",
+    "tap": "^10.7.3",
     "then-sleep": "^1.0.1"
   },
   "dependencies": {

--- a/test/close.test.js
+++ b/test/close.test.js
@@ -301,3 +301,43 @@ test('close without a cb', (t) => {
 
   app.close()
 })
+
+test('close passing not a function', (t) => {
+  t.plan(1)
+
+  const app = boot()
+
+  app.onClose((instance, done) => {
+    t.ok('called')
+    done()
+  })
+
+  t.throws(() => app.close({}), { message: 'not a function' })
+})
+
+test('close passing not a function', (t) => {
+  t.plan(1)
+
+  const app = boot()
+
+  app.onClose((instance, done) => {
+    t.ok('called')
+    done()
+  })
+
+  t.throws(() => app.close({}), { message: 'not a function' })
+})
+
+test('close passing not a function when wrapping', (t) => {
+  t.plan(1)
+
+  const app = {}
+  boot(app)
+
+  app.onClose((instance, done) => {
+    t.ok('called')
+    done()
+  })
+
+  t.throws(() => app.close({}), { message: 'not a function' })
+})


### PR DESCRIPTION
If calling `.close()` with a non-function, throw.