### PR TITLE
Added `wait` api

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ async function third (instance, opts) {
   * <a href="#use"><code>instance.<b>use()</b></code></a>
   * <a href="#after"><code>instance.<b>after()</b></code></a>
   * <a href="#ready"><code>instance.<b>ready()</b></code></a>
+  * <a href="#wait"><code>instance.<b>wait()</b></code></a>
   * <a href="#override"><code>instance.<b>override()</b></code></a>
   * <a href="#onClose"><code>instance.<b>onClose()</b></code></a>
   * <a href="#close"><code>instance.<b>close()</b></code></a>
@@ -262,9 +263,22 @@ app.ready(function (err, context, done) {
 Returns the instance on which `ready` is called, to support a chainable API.
 
 -------------------------------------------------------
+<a name="wait"></a>
+
+### app.wait()
+If you are using async await, you can avoid the use of `after` and `ready`, and just use the `wait` api which returns a promise.
+```js
+
+await app.use(plugin).wait()
+
+async function plugin (instance, opts) {
+  console.log('plugin')  
+}
+```
+-------------------------------------------------------
 <a name="express"></a>
 
-### avioo.express(app)
+### avvio.express(app)
 
 Same as:
 

--- a/boot.js
+++ b/boot.js
@@ -206,6 +206,23 @@ Boot.prototype.after = function (func, cb) {
   return this
 }
 
+Boot.prototype.wait = function () {
+  return new Promise((resolve, reject) => {
+    this.use(_wait.bind(this))
+
+    function _wait (s, opts, done) {
+      process.nextTick(done)
+      var err = this._error
+      this._error = null
+      if (err) {
+        reject(err)
+      } else {
+        resolve()
+      }
+    }
+  })
+}
+
 Boot.prototype.onClose = function (func) {
   this._closeQ.unshift(func, callback.bind(this))
 

--- a/test/async-await.js
+++ b/test/async-await.js
@@ -117,3 +117,42 @@ test('multiple reentrant plugin loading', (t) => {
     t.pass('booted')
   })
 })
+
+test('wait plugin registration', async (t) => {
+  const app = boot()
+
+  await app.use(plugin).wait()
+
+  async function plugin (instance, opts) {
+    t.ok('called')
+  }
+})
+
+test('wait plugin registration (multiple)', async (t) => {
+  const app = boot()
+
+  await app
+    .use(plugin)
+    .use(plugin)
+    .use(plugin)
+    .wait()
+
+  async function plugin (instance, opts) {
+    t.ok('called')
+  }
+})
+
+test('wait plugin registration (errored)', async (t) => {
+  const app = boot()
+
+  try {
+    await app.use(plugin).wait()
+  } catch (err) {
+    t.is(err.message, 'kaboom')
+  }
+
+  async function plugin (instance, opts) {
+    t.ok('called')
+    throw new Error('kaboom')
+  }
+})

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -205,3 +205,47 @@ test('promise long resolve', (t) => {
     t.notOk(err)
   })
 })
+
+test('wait plugin registration', (t) => {
+  t.plan(2)
+
+  const app = boot()
+
+  app.use(function (server, opts, done) {
+    done()
+  })
+
+  app.wait()
+    .then(() => {
+      t.pass('called')
+    })
+    .catch(err => {
+      t.fail(err)
+    })
+
+  app.on('start', () => {
+    t.pass('booted')
+  })
+})
+
+test('wait plugin registration (errored)', (t) => {
+  t.plan(2)
+
+  const app = boot()
+
+  app.use(function (server, opts, done) {
+    done(new Error('kaboom'))
+  })
+
+  app.wait()
+    .then(() => {
+      t.fail('we should not be here')
+    })
+    .catch(err => {
+      t.is(err.message, 'kaboom')
+    })
+
+  app.on('start', () => {
+    t.pass('booted')
+  })
+})


### PR DESCRIPTION
As titled, in this way we can provide a better support for *async-await*.
See https://github.com/fastify/fastify/issues/481 for context.