### PR TITLE
After event should be fired before calling ready handler

### DIFF
--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -278,3 +278,16 @@ test('throws correctly if registering after ready', (t) => {
     }, 'root plugin has already booted')
   })
 })
+
+test('`start` event should launch before the ready callback', (t) => {
+  t.plan(1)
+  let startHandlerCounter = 0
+
+  const app = boot()
+  app.on('start', function () {
+    startHandlerCounter += 1
+  })
+  app.ready(function () {
+    t.equal(startHandlerCounter, 1)
+  })
+})


### PR DESCRIPTION
This issue was suggested in this comment https://github.com/fastify/fastify/pull/671#discussion_r162013010

I don't know if the current behavior is correct or not.
This PR adds a test for checking what I expected.

**NB:** I didn't found any tests that check that call order.