### PR TITLE
Stop chain on failure

### DIFF
--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -278,3 +278,18 @@ test('throws correctly if registering after ready', (t) => {
     }, 'root plugin has already booted')
   })
 })
+
+test('failure use should stop the chain', (t) => {
+  t.plan(2)
+
+  const app = boot()
+
+  app.use((a, b, done) => {
+    t.pass()
+    done(new Error('Kaboom!'))
+  })
+    .use((a, b, done) => t.fail('This should not be called'))
+  app.ready(function (err) {
+    t.error(err)
+  })
+})


### PR DESCRIPTION
As a developer, I want that `avvio` should stop the process start up if some plugin fails

This PR provides a simple test to start a discussion about this feature.