### PR TITLE
Catch exceptions in parent.override

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -36,7 +36,7 @@ Plugin.prototype.exec = function (server, cb) {
   try {
     this.server = this.parent.override(server, func, this.opts)
   } catch (err) {
-    debug('exec errored', name)
+    debug('override errored', name)
     return cb(err)
   }
 

--- a/plugin.js
+++ b/plugin.js
@@ -36,6 +36,7 @@ Plugin.prototype.exec = function (server, cb) {
   try {
     this.server = this.parent.override(server, func, this.opts)
   } catch (err) {
+    debug('exec errored', name)
     return cb(err)
   }
 

--- a/plugin.js
+++ b/plugin.js
@@ -33,7 +33,11 @@ Plugin.prototype.exec = function (server, cb) {
     return
   }
 
-  this.server = this.parent.override(server, func, this.opts)
+  try {
+    this.server = this.parent.override(server, func, this.opts)
+  } catch (err) {
+    return cb(err)
+  }
 
   debug('exec', name)
 

--- a/test/catch-override-exception.test.js
+++ b/test/catch-override-exception.test.js
@@ -1,0 +1,24 @@
+'use strict'
+
+const t = require('tap')
+const boot = require('..')
+
+t.plan(2)
+
+const server = {}
+
+const app = boot(server, {
+  autostart: false
+})
+app.override = function () {
+  throw Error('catch it')
+}
+
+app
+  .use(function () {})
+  .start()
+
+app.ready(function (err) {
+  t.type(err, Error)
+  t.match(err, /catch it/)
+})


### PR DESCRIPTION
This PR should allow https://github.com/fastify/fastify/pull/778 to be fixed.

N.B.: I think `Boot.prototype.start` should return `this`. Do you?