### PR TITLE
wrapped close should return a promise with no callback

### DIFF
--- a/boot.js
+++ b/boot.js
@@ -58,13 +58,14 @@ function wrap (server, opts, instance) {
     if (func && typeof func !== 'function') {
       throw new Error('not a function')
     }
+
     if (func) {
       instance.close(encapsulateThreeParam(func, this))
       return this
-    } else {
-      // this is a Promise
-      return instance.close()
     }
+
+    // this is a Promise
+    return instance.close()
   }
 }
 

--- a/boot.js
+++ b/boot.js
@@ -58,8 +58,13 @@ function wrap (server, opts, instance) {
     if (func && typeof func !== 'function') {
       throw new Error('not a function')
     }
-    instance.close(encapsulateThreeParam(func, this))
-    return this
+    if (func) {
+      instance.close(encapsulateThreeParam(func, this))
+      return this
+    } else {
+      // this is a Promise
+      return instance.close()
+    }
   }
 }
 

--- a/test/close.test.js
+++ b/test/close.test.js
@@ -394,3 +394,13 @@ test('close without a cb returns a promise', (t) => {
     t.pass('promise resolves')
   })
 })
+
+test('close without a cb returns a promise when attaching to a server', (t) => {
+  t.plan(1)
+
+  const server = {}
+  boot(server)
+  server.close().then(() => {
+    t.pass('promise resolves')
+  })
+})


### PR DESCRIPTION
This fixes two bugs:

1. `await fastify.close()` actually waits for close to happen
2. stop errors from bubbling up if they happen when closing (they will end up in the rejection handler).

cc @StarpTech @allevo