### PR TITLE
Add Typescript definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ jspm_packages
 # vscode
 *.code-workspace
 .vscode
+
+# package-lock
+package-lock.json

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,70 @@
+import { EventEmitter } from "events";
+
+declare function avvio(done?: Function): avvio.Avvio<null>;
+declare function avvio<I>(
+  instance: I,
+  options?: avvio.Options,
+  done?: Function
+): avvio.Avvio<I>;
+
+/**
+ * Typescript cannot manage changes related to options "expose"
+ * because undefined before runtime
+ */
+declare namespace avvio {
+  type context<I> = I extends null ? Avvio<I> : mixedInstance<I>;
+  type mixedInstance<I> = I & Server<I>;
+
+  interface Options {
+    expose?: {
+      use?: string;
+      after?: string;
+      ready?: string;
+    };
+    autostart?: boolean;
+  }
+
+  interface Plugin<O, I> {
+    (server: context<I>, options: O, done: (err?: Error) => void): void;
+  }
+
+  interface Server<I> {
+    use<O>(fn: avvio.Plugin<O, I>, options?: O): this;
+
+    after(fn: (err: Error) => void): this;
+    after(fn: (err: Error, done: Function) => void): this;
+    after(fn: (err: Error, context: context<I>, done: Function) => void): this;
+
+    ready(): Promise<context<I>>;
+    ready(callback: (err?: Error) => void): any;
+    ready(callback: (err: Error, done: Function) => void): any;
+    ready(
+      callback: (err: Error, context: context<I>, done: Function) => void
+    ): any;
+  }
+
+  interface Avvio<I> extends EventEmitter, Server<I> {
+    on(event: "start", listener: () => void): this;
+    on(event: "preReady", listener: () => void): this;
+    on(event: "close", listener: () => void): this;
+
+    start(): this;
+
+    override: (
+      server: context<I>,
+      fn: Plugin<any, I>,
+      options: any
+    ) => context<I>;
+
+    onClose(fn: (context: context<I>, done: Function) => void): this;
+
+    close(fn: (err: Error) => void): void;
+    close(fn: (err: Error, done: Function) => void): void;
+    close(fn: (err: Error, context: context<I>, done: Function) => void): void;
+
+    started: boolean;
+    booted: boolean;
+  }
+}
+
+export = avvio;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Asynchronous bootstrapping of Node applications",
   "main": "boot.js",
   "scripts": {
-    "test": "standard && tap -j4 test/*test.js"
+    "typescript": "tsc --project ./test/types/tsconfig.json",
+    "test": "standard && tap -j4 test/*test.js && npm run typescript"
   },
   "precommit": "test",
   "repository": {
@@ -30,11 +31,13 @@
   },
   "homepage": "https://github.com/mcollina/avvio#readme",
   "devDependencies": {
+    "@types/node": "^10.3.0",
     "express": "^4.16.3",
     "pre-commit": "^1.2.2",
     "standard": "^11.0.0",
     "tap": "^11.1.3",
-    "then-sleep": "^1.0.1"
+    "then-sleep": "^1.0.1",
+    "typescript": "^2.9.1"
   },
   "dependencies": {
     "debug": "^3.1.0",

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -1,0 +1,365 @@
+import * as avvio from "../../";
+
+{
+  // avvio with no argument
+  const app = avvio();
+
+  app.override = (server, fn, options) => server;
+
+  app.use(
+    (server, opts, done) => {
+      server.use;
+      server.after;
+      server.ready;
+      server.on;
+      server.start;
+      server.override;
+      server.onClose;
+      server.close;
+
+      opts.mySuper;
+
+      done();
+    },
+    { mySuper: "option" }
+  );
+
+  app.use(async (server, options) => {
+    server.use;
+    server.after;
+    server.ready;
+    server.on;
+    server.start;
+    server.override;
+    server.onClose;
+    server.close;
+  });
+
+  app.after(err => {
+    if (err) throw err;
+  });
+
+  app.after((err: Error, done: Function) => {
+    done();
+  });
+
+  app.after((err: Error, context: avvio.context<null>, done: Function) => {
+    context.use;
+    context.after;
+    context.ready;
+    context.on;
+    context.start;
+    context.override;
+    context.onClose;
+    context.close;
+
+    done();
+  });
+
+  app.ready().then(context => {
+    context.use;
+    context.after;
+    context.ready;
+    context.on;
+    context.start;
+    context.override;
+    context.onClose;
+    context.close;
+  });
+
+  app.ready(err => {
+    if (err) throw err;
+  });
+
+  app.ready((err: Error, done: Function) => {
+    done();
+  });
+
+  app.ready((err: Error, context: avvio.context<null>, done: Function) => {
+    context.use;
+    context.after;
+    context.ready;
+    context.on;
+    context.start;
+    context.override;
+    context.onClose;
+    context.close;
+
+    done();
+  });
+
+  app.close(err => {
+    if (err) throw err;
+  });
+
+  app.close((err: Error, done: Function) => {
+    done();
+  });
+
+  app.close((err: Error, context: avvio.context<null>, done: Function) => {
+    context.use;
+    context.after;
+    context.ready;
+    context.on;
+    context.start;
+    context.override;
+    context.onClose;
+    context.close;
+
+    done();
+  });
+
+  app.onClose((context, done) => {
+    context.use;
+    context.after;
+    context.ready;
+    context.on;
+    context.start;
+    context.override;
+    context.onClose;
+    context.close;
+
+    done();
+  });
+}
+
+{
+  // avvio with done
+  const app = avvio(() => undefined);
+
+  app.use(
+    (server, opts, done) => {
+      server.use;
+      server.after;
+      server.ready;
+      server.on;
+      server.start;
+      server.override;
+      server.onClose;
+      server.close;
+
+      opts.mySuper;
+
+      done();
+    },
+    { mySuper: "option" }
+  );
+
+  app.use(async (server, options) => {
+    server.use;
+    server.after;
+    server.ready;
+    server.on;
+    server.start;
+    server.override;
+    server.onClose;
+    server.close;
+  });
+
+  app.after(err => {
+    if (err) throw err;
+  });
+
+  app.after((err: Error, done: Function) => {
+    done();
+  });
+
+  app.after((err: Error, context: avvio.context<null>, done: Function) => {
+    context.use;
+    context.after;
+    context.ready;
+    context.on;
+    context.start;
+    context.override;
+    context.onClose;
+    context.close;
+
+    done();
+  });
+
+  app.ready().then(context => {
+    context.use;
+    context.after;
+    context.ready;
+    context.on;
+    context.start;
+    context.override;
+    context.onClose;
+    context.close;
+  });
+
+  app.ready(err => {
+    if (err) throw err;
+  });
+
+  app.ready((err: Error, done: Function) => {
+    done();
+  });
+
+  app.ready((err: Error, context: avvio.context<null>, done: Function) => {
+    context.use;
+    context.after;
+    context.ready;
+    context.on;
+    context.start;
+    context.override;
+    context.onClose;
+    context.close;
+
+    done();
+  });
+
+  app.close(err => {
+    if (err) throw err;
+  });
+
+  app.close((err: Error, done: Function) => {
+    done();
+  });
+
+  app.close((err: Error, context: avvio.context<null>, done: Function) => {
+    context.use;
+    context.after;
+    context.ready;
+    context.on;
+    context.start;
+    context.override;
+    context.onClose;
+    context.close;
+
+    done();
+  });
+
+  app.onClose((context, done) => {
+    context.use;
+    context.after;
+    context.ready;
+    context.on;
+    context.start;
+    context.override;
+    context.onClose;
+    context.close;
+
+    done();
+  });
+}
+
+{
+  const server = { typescriptIs: "amazing" };
+  // avvio with server
+  const app = avvio(server);
+
+  app.use(
+    (server, opts, done) => {
+      server.use;
+      server.after;
+      server.ready;
+      server.typescriptIs;
+
+      opts.mySuper;
+
+      done();
+    },
+    { mySuper: "option" }
+  );
+
+  app.use(async (server, options) => {
+    server.use;
+    server.after;
+    server.ready;
+    server.typescriptIs;
+  });
+
+  app.after(err => {
+    if (err) throw err;
+  });
+
+  app.after((err: Error, done: Function) => {
+    done();
+  });
+
+  app.after(
+    (err: Error, context: avvio.context<typeof server>, done: Function) => {
+      context.use;
+      context.after;
+      context.ready;
+      context.typescriptIs;
+
+      done();
+    }
+  );
+
+  app.ready().then(context => {
+    context.use;
+    context.after;
+    context.ready;
+    context.typescriptIs;
+  });
+
+  app.ready(err => {
+    if (err) throw err;
+  });
+
+  app.ready((err: Error, done: Function) => {
+    done();
+  });
+
+  app.ready(
+    (err: Error, context: avvio.context<typeof server>, done: Function) => {
+      context.use;
+      context.after;
+      context.ready;
+      context.typescriptIs;
+
+      done();
+    }
+  );
+
+  app.close(err => {
+    if (err) throw err;
+  });
+
+  app.close((err: Error, done: Function) => {
+    done();
+  });
+
+  app.close(
+    (err: Error, context: avvio.context<typeof server>, done: Function) => {
+      context.use;
+      context.after;
+      context.ready;
+      context.typescriptIs;
+
+      done();
+    }
+  );
+
+  app.onClose((context, done) => {
+    context.use;
+    context.after;
+    context.ready;
+    context.typescriptIs;
+
+    done();
+  });
+}
+
+{
+  const server = { hello: "world" };
+  const options = {
+    autostart: false,
+    expose: { after: "after", ready: "ready", use: "use" }
+  };
+  // avvio with server and options
+  const app = avvio(server, options);
+}
+
+{
+  const server = { hello: "world" };
+  const options = {
+    autostart: false,
+    expose: { after: "after", ready: "ready", use: "use" }
+  };
+  // avvio with server, options and done callback
+  const app = avvio(server, options, () => undefined);
+}

--- a/test/types/tsconfig.json
+++ b/test/types/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "noEmit": true,
+    "strict": true
+  },
+  "files": ["./index.ts"]
+}


### PR DESCRIPTION
Hello

Here is my second attempt to write Typescript definitions for this project.

Already, the main problem is that Typescript cannot handle changing the `expose` option, knowing that they are undefined before the runtime. It is always possible to change this by copying the definitions into an `index.d.ts` file at the root of your project, which will contain the following:
```ts
declare module "avvio" {
    // insert definitions here by changing `use`, `after` and `ready` values.
}
```

So I'd like you to check the function feedback values, just to be sure. You can see that from the test files.

Also to be able to create the right definitions, I introduced the type `avvio.context`. This Type takes relies on conditional typing. If an object is passed as instance in avvio, typescript will add the use, after and ready to the instance functions. If nothing is passed (`null`), the context will be the Boot.

Feel free to ask me questions about this PR ^^
