### PR TITLE
Add 'wrap' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ async function third (instance, opts) {
 
 Starts the avvio sequence.
 As the name suggest, `instance` is the object representing your application.
-Avvio will add the functions `use`, `after` and `ready` to the instance.
+Avvio will add the functions `use`, `after` and `ready` to the instance (see options below).
 
 ```js
 const server = {}
@@ -110,7 +110,7 @@ Options:
 * `expose`: a key/value property to change how `use`, `after` and `ready` are exposed.
 * `autostart`: do not start loading plugins automatically, but wait for
   a call to [`.start()`](#start)  or [`.ready()`](#ready).
-
+* `wrap`: Determines whether avvio must mutate the instance object by adding `use`, `after` and `ready`.
 
 Events:
 

--- a/boot.js
+++ b/boot.js
@@ -84,13 +84,17 @@ function Boot (server, opts, done) {
   opts = opts || {}
 
   if (!(this instanceof Boot)) {
-    const instance = new Boot(server, opts, done)
-
     if (opts.wrap !== false) {
       opts.wrap = true
     }
 
-    if (server && opts.wrap) {
+    if (opts.wrap === false) {
+      server = Object.assign({}, server)
+    }
+
+    const instance = new Boot(server, opts, done)
+
+    if (server) {
       wrap(server, opts, instance)
     }
 

--- a/boot.js
+++ b/boot.js
@@ -86,7 +86,11 @@ function Boot (server, opts, done) {
   if (!(this instanceof Boot)) {
     const instance = new Boot(server, opts, done)
 
-    if (server) {
+    if (opts.wrap !== false) {
+      opts.wrap = true
+    }
+
+    if (server && opts.wrap) {
       wrap(server, opts, instance)
     }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,6 +22,7 @@ declare namespace avvio {
       ready?: string;
     };
     autostart?: boolean;
+    wrap?: boolean;
   }
 
   interface Plugin<O, I> {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -228,8 +228,8 @@ test('do not autostart', (t) => {
 })
 
 test('do not wrap instance', (t) => {
-  const server = {}
-  boot(server, {
+  const server = { wesh: 'alors' }
+  const app = boot(server, {
     wrap: false
   })
 
@@ -237,7 +237,17 @@ test('do not wrap instance', (t) => {
   t.type(server.ready, undefined, 'should not wrap instance')
   t.type(server.use, undefined, 'should not wrap instance')
 
-  t.end()
+  app.use(function (s, opts, done) {
+    t.type(s.after, 'function', 'should wrap instance internally')
+    t.type(s.ready, 'function', 'should wrap instance internally')
+    t.type(s.use, 'function', 'should wrap instance internally')
+
+    done()
+  })
+
+  app.on('start', () => {
+    t.end()
+  })
 })
 
 test('start with ready', (t) => {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -227,6 +227,19 @@ test('do not autostart', (t) => {
   t.end()
 })
 
+test('do not wrap instance', (t) => {
+  const server = {}
+  boot(server, {
+    wrap: false
+  })
+
+  t.type(server.after, undefined, 'should not wrap instance')
+  t.type(server.ready, undefined, 'should not wrap instance')
+  t.type(server.use, undefined, 'should not wrap instance')
+
+  t.end()
+})
+
 test('start with ready', (t) => {
   t.plan(2)
 

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -346,12 +346,12 @@ import * as avvio from "../../";
 
 {
   const server = { hello: "world" };
-  const options = {
-    autostart: false,
-    expose: { after: "after", ready: "ready", use: "use" }
-  };
   // avvio with server and options
-  const app = avvio(server, options);
+  const app = avvio(server, {
+    autostart: false,
+    expose: { after: "after", ready: "ready", use: "use" },
+    wrap: false
+  });
 }
 
 {


### PR DESCRIPTION
Hello,

This PR is dedicated to adding a flag named `wrap` in the avvio options.

In some cases, avvio should not mutate the instance, but simply reuse it internally. it would allow to have a 100% predictive behavior with Typescript, but also to leave the choice to the developer of the organization of its object (with or without `use`, `after` and `ready`).

Feel free to ask questions about this PR ^^