### PR TITLE
Avoid swallowing errors in .after() without argument

### DIFF
--- a/boot.js
+++ b/boot.js
@@ -364,7 +364,10 @@ function encapsulateThreeParam (func, that) {
   function _encapsulateThreeParam (err, cb) {
     if (!func) {
       process.nextTick(cb)
-    } else if (func.length === 0 || func.length === 1) {
+    } else if (func.length === 0) {
+      func()
+      process.nextTick(cb, err)
+    } else if (func.length === 1) {
       func(err)
       process.nextTick(cb)
     } else if (func.length === 2) {

--- a/test/after-pass-through.test.js
+++ b/test/after-pass-through.test.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const t = require('tap')
+const boot = require('..')
+const app = {}
+
+boot(app)
+
+t.plan(5)
+
+app.use(function (f, opts) {
+  return Promise.reject(new Error('kaboom'))
+}).after(function (err, cb) {
+  t.pass('this is just called')
+  cb(err)
+}).after(function () {
+  t.pass('this is just called')
+}).after(function (err, cb) {
+  t.pass('this is just called')
+  cb(err)
+})
+
+app.ready().then(() => {
+  t.fail('this should not be called')
+}).catch(err => {
+  t.ok(err)
+  t.strictEqual(err.message, 'kaboom')
+})


### PR DESCRIPTION
This is going to be contentious about the semversiness.

Without this change, the following fails:

```js
  const fastify = fastify()
  const payload = { hello: 'world' }

  fastify.register((instance, opts) => {
    return promise.reject(new error('kaboom'))
  }).after(function () {
    t.pass('after is called')
  })

  fastify.inject({
    method: 'get',
    url: '/'
  }).then(() => {
    t.fail('this should not be called')
  }).catch(err => {
    t.ok(err)
    t.strictequal(err.message, 'kaboom')
  })
```

Note that this could cause several _horrible_ bugs like having 404 with routes not defined because an error got swallowed.