### PR TITLE
Fix documentation for multiple calls to `done`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,8 @@ function plugin (server, opts, done) {
 
 app.use(plugin)
 ```
-`done` must be called only once, when your plugin is ready to go.
+`done` should be called only once, when your plugin is ready to go.  Additional
+calls to `done` are ignored.
 
 async/await is also supported:
 

--- a/test/twice-done.test.js
+++ b/test/twice-done.test.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const test = require('tap').test
+const boot = require('..')
+
+test('calling done twice does not throw error', (t) => {
+  t.plan(2)
+
+  const app = boot()
+
+  app
+    .use(twiceDone)
+    .ready((err) => {
+      t.notOk(err, 'no error')
+    })
+
+  function twiceDone (s, opts, done) {
+    done()
+    done()
+    t.pass('did not throw')
+  }
+})


### PR DESCRIPTION
Add test to verify lack of exception from calling done twice.

Fixes #39