### PR TITLE
Added support for a function in place of opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,22 @@
 # avvio
 
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](http://standardjs.com/)
- [![Build Status](https://travis-ci.org/mcollina/avvio.svg)](https://travis-ci.org/mcollina/avvio)
+[![Build Status](https://travis-ci.org/mcollina/avvio.svg)](https://travis-ci.org/mcollina/avvio)
 
-Asynchronous bootstrapping is hard, different things can go wrong, *error handling* and *load order* just to name a few. The aim of this module is to make it simple.
+Asynchronous bootstrapping is hard, different things can go wrong, _error handling_ and _load order_ just to name a few. The aim of this module is to make it simple.
 
-`avvio` is fully *reentrant* and *graph-based*. You can load
-components/plugins *within* plugins, and be still sure that things will
+`avvio` is fully _reentrant_ and _graph-based_. You can load
+components/plugins _within_ plugins, and be still sure that things will
 happen in the right order. At the end of the loading, your application will start.
 
-* [Install](#install)
-* [Example](#example)
-* [API](#api)
-* [Acknowledgements](#acknowledgements)
-* [License](#license)
+- [Install](#install)
+- [Example](#example)
+- [API](#api)
+- [Acknowledgements](#acknowledgements)
+- [License](#license)
 
 <a name="install"></a>
+
 ## Install
 
 To install `avvio`, simply use npm:
@@ -25,65 +26,65 @@ npm install avvio --save
 ```
 
 <a name="example"></a>
+
 ## Example
 
 The example below can be found [here][example] and run using `node example.js`.
 It demonstrates how to use `avvio` to load functions / plugins in order.
 
-
 ```js
-'use strict'
+"use strict";
 
-const app = require('avvio')()
+const app = require("avvio")();
 
-app
-  .use(first, { hello: 'world' })
-  .after((err, cb) => {
-    console.log('after first and second')
-    cb()
-  })
+app.use(first, { hello: "world" }).after((err, cb) => {
+  console.log("after first and second");
+  cb();
+});
 
-app.use(third)
+app.use(third);
 
-app.ready(function (err) {
+app.ready(function(err) {
   // the error must be handled somehow
   if (err) {
-    throw err
+    throw err;
   }
-  console.log('application booted!')
-})
+  console.log("application booted!");
+});
 
-function first (instance, opts, cb) {
-  console.log('first loaded', opts)
-  instance.use(second)
-  cb()
+function first(instance, opts, cb) {
+  console.log("first loaded", opts);
+  instance.use(second);
+  cb();
 }
 
-function second (instance, opts, cb) {
-  console.log('second loaded')
-  process.nextTick(cb)
+function second(instance, opts, cb) {
+  console.log("second loaded");
+  process.nextTick(cb);
 }
 
 // async/await or Promise support
-async function third (instance, opts) {
-  console.log('third loaded')
+async function third(instance, opts) {
+  console.log("third loaded");
 }
 ```
 
 <a name="api"></a>
+
 ## API
 
-  * <a href="#constructor"><code><b>avvio()</b></code></a>
-  * <a href="#use"><code>instance.<b>use()</b></code></a>
-  * <a href="#after"><code>instance.<b>after()</b></code></a>
-  * <a href="#ready"><code>instance.<b>ready()</b></code></a>
-  * <a href="#start"><code>instance.<b>start()</b></code></a>
-  * <a href="#override"><code>instance.<b>override()</b></code></a>
-  * <a href="#onClose"><code>instance.<b>onClose()</b></code></a>
-  * <a href="#close"><code>instance.<b>close()</b></code></a>
-  * <a href="#express"><code>avvio.<b>express()</b></code></a>
+- <a href="#constructor"><code><b>avvio()</b></code></a>
+- <a href="#use"><code>instance.<b>use()</b></code></a>
+- <a href="#after"><code>instance.<b>after()</b></code></a>
+- <a href="#ready"><code>instance.<b>ready()</b></code></a>
+- <a href="#start"><code>instance.<b>start()</b></code></a>
+- <a href="#override"><code>instance.<b>override()</b></code></a>
+- <a href="#onClose"><code>instance.<b>onClose()</b></code></a>
+- <a href="#close"><code>instance.<b>close()</b></code></a>
+- <a href="#express"><code>avvio.<b>express()</b></code></a>
 
--------------------------------------------------------
+---
+
 <a name="constructor"></a>
 
 ### avvio([instance], [options], [started])
@@ -93,53 +94,57 @@ As the name suggest, `instance` is the object representing your application.
 Avvio will add the functions `use`, `after` and `ready` to the instance.
 
 ```js
-const server = {}
+const server = {};
 
-require('avvio')(server)
+require("avvio")(server);
 
-server.use(function first (s, opts, cb) {
-  // s is the same of server
-  s.use(function second (s, opts, cb) {
-    cb()
+server
+  .use(function first(s, opts, cb) {
+    // s is the same of server
+    s.use(function second(s, opts, cb) {
+      cb();
+    });
+    cb();
   })
-  cb()
-}).after(function (err, cb) {
-  // after first and second are finished
-  cb()
-})
+  .after(function(err, cb) {
+    // after first and second are finished
+    cb();
+  });
 ```
 
 Options:
 
-* `expose`: a key/value property to change how `use`, `after` and `ready` are exposed.
-* `autostart`: do not start loading plugins automatically, but wait for
+- `expose`: a key/value property to change how `use`, `after` and `ready` are exposed.
+- `autostart`: do not start loading plugins automatically, but wait for
   a call to [`.start()`](#start)  or [`.ready()`](#ready).
-* `timeout`: the number of millis to wait a plugin to load after which
+- `timeout`: the number of millis to wait a plugin to load after which
   it will error with code `ERR_AVVIO_PLUGIN_TIMEOUT`. Default
   `0` (disabled).
 
 Events:
 
-* `'start'`  when the application starts
-* `'preReady'` fired before the ready queue is run
+- `'start'`  when the application starts
+- `'preReady'` fired before the ready queue is run
 
 The `avvio` function can also be used as a
 constructor to inherit from.
+
 ```js
-function Server () {}
-const app = require('avvio')(new Server())
+function Server() {}
+const app = require("avvio")(new Server());
 
-app.use(function (s, opts, done) {
+app.use(function(s, opts, done) {
   // your code
-  done()
-})
+  done();
+});
 
-app.on('start', () => {
+app.on("start", () => {
   // you app can start
-})
+});
 ```
 
--------------------------------------------------------
+---
+
 <a name="use"></a>
 
 ### app.use(func, [optsOrFunc])
@@ -148,27 +153,29 @@ Loads one or more functions asynchronously.
 
 The function **must** have the signature: `instance, options, done`
 
-However, if the function is a `Promise` (i.e. `async`), it **must** have the signature: `instance, options`
+However, if the function returns a `Promise` (i.e. `async`), the above function signature is not required.
 
 Plugin example:
+
 ```js
-function plugin (server, opts, done) {
-  done()
+function plugin(server, opts, done) {
+  done();
 }
 
-app.use(plugin)
+app.use(plugin);
 ```
-`done` should be called only once, when your plugin is ready to go.  Additional
+
+`done` should be called only once, when your plugin is ready to go. Additional
 calls to `done` are ignored.
 
 async/await is also supported:
 
 ```js
-async function plugin (server, opts) {
-  await sleep(10)
+async function plugin(server, opts) {
+  await sleep(10);
 }
 
-app.use(plugin)
+app.use(plugin);
 ```
 
 `use` returns the instance on which `use` is called, to support a chainable API.
@@ -176,9 +183,9 @@ app.use(plugin)
 A function that returns the options argument instead of an object is supported as well:
 
 ```js
-function plugin (server, opts, done) {
-  console.log(opts) // Evaluates to: { hello: 'world' }
-  done()
+function plugin(server, opts, done) {
+  console.log(opts); // Evaluates to: { hello: 'world' }
+  done();
 }
 
 /**
@@ -187,37 +194,40 @@ function plugin (server, opts, done) {
  */
 const func = parent => {
   return {
-    hello: 'world'
-  }
-}
+    hello: "world"
+  };
+};
 
-app.use(plugin, func)
+app.use(plugin, func);
 ```
 
 This is useful in cases where an injected variable from a plugin needs to be made available to another.
 
--------------------------------------------------------
+---
+
 <a name="error-handling"></a>
+
 #### Error handling
 
 In order to handle errors in the loading plugins, you must use the
 `.ready()` method, like so:
 
 ```js
-app.use(function (instance, opts, done) {
-  done(new Error('error'))
-}, opts)
+app.use(function(instance, opts, done) {
+  done(new Error("error"));
+}, opts);
 
-app.ready(function (err) {
-  if (err) throw err
-})
+app.ready(function(err) {
+  if (err) throw err;
+});
 ```
 
 When an error happens, the loading of plugins will stop until there is
 an [`after`](#after) callback specified. Otherwise, it will be handled
 in [`ready`](#ready).
 
--------------------------------------------------------
+---
+
 <a name="after"></a>
 
 ### app.after(func(error, [context], [done]))
@@ -226,6 +236,7 @@ Calls a function after all the previously defined plugins are loaded, including
 all their dependencies. The `'start'` event is not emitted yet.
 
 The callback changes basing on the parameters your are giving:
+
 1. If no parameter is given to the callback and there is an error, that error will be passed to the next error handler.
 2. If one parameter is given to the callback, that parameter will be the `error` object.
 3. If two parameters are given to the callback, the first will be the `error` object, the second will be the `done` callback.
@@ -275,7 +286,8 @@ app.after(async function () {
 
 Returns the instance on which `after` is called, to support a chainable API.
 
--------------------------------------------------------
+---
+
 <a name="ready"></a>
 
 ### app.ready([func(error, [context], [done])])
@@ -283,12 +295,13 @@ Returns the instance on which `after` is called, to support a chainable API.
 Calls a function after all the plugins and `after` call are completed, but before `'start'` is emitted. `ready` callbacks are executed one at a time.
 
 The callback changes basing on the parameters your are giving:
+
 1. If no parameter is given to the callback and there is an error, that error will be passed to the next error handler.
 2. If one parameter is given to the callback, that parameter will be the `error` object.
 3. If two parameters are given to the callback, the first will be the `error` object, the second will be the `done` callback.
 4. If three parameters are given to the callback, the first will be the `error` object, the second will be the top level `context` unless you have specified both server and override, in that case the `context` will be what the override returns, and the third the `done` callback.
 
-If no callback is provided `ready` will return a Promise that is resolved or rejected once plugins and `after` calls are completed.  On success `context` is provided to the `.then` callback, if an error occurs it is provided to the `.catch` callback.
+If no callback is provided `ready` will return a Promise that is resolved or rejected once plugins and `after` calls are completed. On success `context` is provided to the `.then` callback, if an error occurs it is provided to the `.catch` callback.
 
 ```js
 const server = {}
@@ -339,7 +352,8 @@ The callback form of this function has no return value.
 If `autostart: false` is passed as an option, calling `.ready()`  will
 also start the boot sequence.
 
--------------------------------------------------------
+---
+
 <a name="start"></a>
 
 ### app.start()
@@ -347,7 +361,8 @@ also start the boot sequence.
 Start the boot sequence, if it was not started yet.
 Returns the `app` instance.
 
--------------------------------------------------------
+---
+
 <a name="express"></a>
 
 ### avvio.express(app)
@@ -355,17 +370,18 @@ Returns the `app` instance.
 Same as:
 
 ```js
-const app = express()
-const avvio = require('avvio')
+const app = express();
+const avvio = require("avvio");
 
 avvio(app, {
   expose: {
-    use: 'load'
+    use: "load"
   }
-})
+});
 ```
 
--------------------------------------------------------
+---
+
 <a name="override"></a>
 
 ### app.override(server, plugin, options)
@@ -375,44 +391,47 @@ It allows the creation of an inheritance chain for the server instances.
 The first parameter is the server instance and the second is the plugin function while the third is the options object that you give to use.
 
 ```js
-const assert = require('assert')
-const server = { count: 0 }
-const app = require('avvio')(server)
+const assert = require("assert");
+const server = { count: 0 };
+const app = require("avvio")(server);
 
-console.log(app !== server, 'override must be set on the Avvio instance')
+console.log(app !== server, "override must be set on the Avvio instance");
 
-app.override = function (s, fn, opts) {
+app.override = function(s, fn, opts) {
   // create a new instance with the
   // server as the prototype
-  const res = Object.create(s)
-  res.count = res.count + 1
+  const res = Object.create(s);
+  res.count = res.count + 1;
 
-  return res
-}
+  return res;
+};
 
-app.use(function first (s1, opts, cb) {
-  assert(s1 !== server)
-  assert(server.isPrototypeOf(s1))
-  assert(s1.count === 1)
-  s1.use(second)
-  cb()
+app.use(function first(s1, opts, cb) {
+  assert(s1 !== server);
+  assert(server.isPrototypeOf(s1));
+  assert(s1.count === 1);
+  s1.use(second);
+  cb();
 
-  function second (s2, opts, cb) {
-    assert(s2 !== s1)
-    assert(s1.isPrototypeOf(s2))
-    assert(s2.count === 2)
-    cb()
+  function second(s2, opts, cb) {
+    assert(s2 !== s1);
+    assert(s1.isPrototypeOf(s2));
+    assert(s2.count === 2);
+    cb();
   }
-})
+});
 ```
--------------------------------------------------------
+
+---
 
 <a name="onClose"></a>
+
 ### app.onClose(func([context], [done]))
 
 Registers a new callback that will be fired once then `close` api is called.
 
 The callback changes basing on the parameters your are giving:
+
 1. If one parameter is given to the callback, that parameter will be the `context`.
 2. If zero or one parameter is given, the callback may return a promise
 3. If two parameters are given to the callback, the first will be the top level `context` unless you have specified both server and override, in that case the `context` will be what the override returns, the second will be the `done` callback.
@@ -452,14 +471,16 @@ If the callback returns a promise, the next onClose callback and the close callb
 `done` must be called only once.
 Returns the instance on which `onClose` is called, to support a chainable API.
 
--------------------------------------------------------
+---
 
 <a name="close"></a>
+
 ### app.close(func(error, [context], [done]))
 
 Starts the shutdown procedure, the callback is called once all the registered callbacks with `onClose` has been executed.
 
 The callback changes based on the parameters your are giving:
+
 1. If one parameter is given to the callback, that parameter will be the `error` object.
 2. If two parameters are given to the callback, the first will be the `error` object, the second will be the `done` callback.
 3. If three parameters are given to the callback, the first will be the `error` object, the second will be the top level `context` unless you have specified both server and override, in that case the `context` will be what the override returns, and the third the `done` callback.
@@ -500,7 +521,7 @@ app.close()
 
 `done` must be called only once.
 
--------------------------------------------------------
+---
 
 ## Acknowledgements
 
@@ -510,5 +531,5 @@ This project was kindly sponsored by [nearForm](http://nearform.com).
 
 Copyright Matteo Collina 2016-2017, Licensed under [MIT][].
 
-[MIT]: ./LICENSE
+[mit]: ./LICENSE
 [example]: ./example.js

--- a/README.md
+++ b/README.md
@@ -142,10 +142,13 @@ app.on('start', () => {
 -------------------------------------------------------
 <a name="use"></a>
 
-### app.use(func, [opts])
+### app.use(func, [optsOrFunc])
 
 Loads one or more functions asynchronously.
+
 The function **must** have the signature: `instance, options, done`
+
+However, if the function is a `Promise` (i.e. `async`), it **must** have the signature: `instance, options`
 
 Plugin example:
 ```js
@@ -164,10 +167,34 @@ async/await is also supported:
 async function plugin (server, opts) {
   await sleep(10)
 }
+
 app.use(plugin)
 ```
 
 `use` returns the instance on which `use` is called, to support a chainable API.
+
+A function that returns the options argument instead of an object is supported as well:
+
+```js
+function plugin (server, opts, done) {
+  console.log(opts) // Evaluates to: { hello: 'world' }
+  done()
+}
+
+/**
+ * If the options argument is a function, it has access to the parent
+ * instance via the first positional variable
+ */
+const func = parent => {
+  return {
+    hello: 'world'
+  }
+}
+
+app.use(plugin, func)
+```
+
+This is useful in cases where an injected variable from a plugin needs to be made available to another.
 
 -------------------------------------------------------
 <a name="error-handling"></a>
@@ -420,7 +447,7 @@ app.onClose(function (context, done) {
 })
 ```
 
-If the callback returns a promise, the next onClose callback and the close callback won't run until the promise is either resolved or rejected. 
+If the callback returns a promise, the next onClose callback and the close callback won't run until the promise is either resolved or rejected.
 
 `done` must be called only once.
 Returns the instance on which `onClose` is called, to support a chainable API.

--- a/README.md
+++ b/README.md
@@ -1,22 +1,21 @@
 # avvio
 
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](http://standardjs.com/)
-[![Build Status](https://travis-ci.org/mcollina/avvio.svg)](https://travis-ci.org/mcollina/avvio)
+ [![Build Status](https://travis-ci.org/mcollina/avvio.svg)](https://travis-ci.org/mcollina/avvio)
 
-Asynchronous bootstrapping is hard, different things can go wrong, _error handling_ and _load order_ just to name a few. The aim of this module is to make it simple.
+Asynchronous bootstrapping is hard, different things can go wrong, *error handling* and *load order* just to name a few. The aim of this module is to make it simple.
 
-`avvio` is fully _reentrant_ and _graph-based_. You can load
-components/plugins _within_ plugins, and be still sure that things will
+`avvio` is fully *reentrant* and *graph-based*. You can load
+components/plugins *within* plugins, and be still sure that things will
 happen in the right order. At the end of the loading, your application will start.
 
-- [Install](#install)
-- [Example](#example)
-- [API](#api)
-- [Acknowledgements](#acknowledgements)
-- [License](#license)
+* [Install](#install)
+* [Example](#example)
+* [API](#api)
+* [Acknowledgements](#acknowledgements)
+* [License](#license)
 
 <a name="install"></a>
-
 ## Install
 
 To install `avvio`, simply use npm:
@@ -26,65 +25,65 @@ npm install avvio --save
 ```
 
 <a name="example"></a>
-
 ## Example
 
 The example below can be found [here][example] and run using `node example.js`.
 It demonstrates how to use `avvio` to load functions / plugins in order.
 
+
 ```js
-"use strict";
+'use strict'
 
-const app = require("avvio")();
+const app = require('avvio')()
 
-app.use(first, { hello: "world" }).after((err, cb) => {
-  console.log("after first and second");
-  cb();
-});
+app
+  .use(first, { hello: 'world' })
+  .after((err, cb) => {
+    console.log('after first and second')
+    cb()
+  })
 
-app.use(third);
+app.use(third)
 
-app.ready(function(err) {
+app.ready(function (err) {
   // the error must be handled somehow
   if (err) {
-    throw err;
+    throw err
   }
-  console.log("application booted!");
-});
+  console.log('application booted!')
+})
 
-function first(instance, opts, cb) {
-  console.log("first loaded", opts);
-  instance.use(second);
-  cb();
+function first (instance, opts, cb) {
+  console.log('first loaded', opts)
+  instance.use(second)
+  cb()
 }
 
-function second(instance, opts, cb) {
-  console.log("second loaded");
-  process.nextTick(cb);
+function second (instance, opts, cb) {
+  console.log('second loaded')
+  process.nextTick(cb)
 }
 
 // async/await or Promise support
-async function third(instance, opts) {
-  console.log("third loaded");
+async function third (instance, opts) {
+  console.log('third loaded')
 }
 ```
 
 <a name="api"></a>
-
 ## API
 
-- <a href="#constructor"><code><b>avvio()</b></code></a>
-- <a href="#use"><code>instance.<b>use()</b></code></a>
-- <a href="#after"><code>instance.<b>after()</b></code></a>
-- <a href="#ready"><code>instance.<b>ready()</b></code></a>
-- <a href="#start"><code>instance.<b>start()</b></code></a>
-- <a href="#override"><code>instance.<b>override()</b></code></a>
-- <a href="#onClose"><code>instance.<b>onClose()</b></code></a>
-- <a href="#close"><code>instance.<b>close()</b></code></a>
-- <a href="#express"><code>avvio.<b>express()</b></code></a>
+  * <a href="#constructor"><code><b>avvio()</b></code></a>
+  * <a href="#use"><code>instance.<b>use()</b></code></a>
+  * <a href="#after"><code>instance.<b>after()</b></code></a>
+  * <a href="#ready"><code>instance.<b>ready()</b></code></a>
+  * <a href="#start"><code>instance.<b>start()</b></code></a>
+  * <a href="#override"><code>instance.<b>override()</b></code></a>
+  * <a href="#onClose"><code>instance.<b>onClose()</b></code></a>
+  * <a href="#close"><code>instance.<b>close()</b></code></a>
+  * <a href="#express"><code>avvio.<b>express()</b></code></a>
 
----
-
+-------------------------------------------------------
 <a name="constructor"></a>
 
 ### avvio([instance], [options], [started])
@@ -94,57 +93,53 @@ As the name suggest, `instance` is the object representing your application.
 Avvio will add the functions `use`, `after` and `ready` to the instance.
 
 ```js
-const server = {};
+const server = {}
 
-require("avvio")(server);
+require('avvio')(server)
 
-server
-  .use(function first(s, opts, cb) {
-    // s is the same of server
-    s.use(function second(s, opts, cb) {
-      cb();
-    });
-    cb();
+server.use(function first (s, opts, cb) {
+  // s is the same of server
+  s.use(function second (s, opts, cb) {
+    cb()
   })
-  .after(function(err, cb) {
-    // after first and second are finished
-    cb();
-  });
+  cb()
+}).after(function (err, cb) {
+  // after first and second are finished
+  cb()
+})
 ```
 
 Options:
 
-- `expose`: a key/value property to change how `use`, `after` and `ready` are exposed.
-- `autostart`: do not start loading plugins automatically, but wait for
+* `expose`: a key/value property to change how `use`, `after` and `ready` are exposed.
+* `autostart`: do not start loading plugins automatically, but wait for
   a call to [`.start()`](#start)  or [`.ready()`](#ready).
-- `timeout`: the number of millis to wait a plugin to load after which
+* `timeout`: the number of millis to wait a plugin to load after which
   it will error with code `ERR_AVVIO_PLUGIN_TIMEOUT`. Default
   `0` (disabled).
 
 Events:
 
-- `'start'`  when the application starts
-- `'preReady'` fired before the ready queue is run
+* `'start'`  when the application starts
+* `'preReady'` fired before the ready queue is run
 
 The `avvio` function can also be used as a
 constructor to inherit from.
-
 ```js
-function Server() {}
-const app = require("avvio")(new Server());
+function Server () {}
+const app = require('avvio')(new Server())
 
-app.use(function(s, opts, done) {
+app.use(function (s, opts, done) {
   // your code
-  done();
-});
+  done()
+})
 
-app.on("start", () => {
+app.on('start', () => {
   // you app can start
-});
+})
 ```
 
----
-
+-------------------------------------------------------
 <a name="use"></a>
 
 ### app.use(func, [optsOrFunc])
@@ -156,26 +151,24 @@ The function **must** have the signature: `instance, options, done`
 However, if the function returns a `Promise` (i.e. `async`), the above function signature is not required.
 
 Plugin example:
-
 ```js
-function plugin(server, opts, done) {
-  done();
+function plugin (server, opts, done) {
+  done()
 }
 
-app.use(plugin);
+app.use(plugin)
 ```
-
-`done` should be called only once, when your plugin is ready to go. Additional
+`done` should be called only once, when your plugin is ready to go.  Additional
 calls to `done` are ignored.
 
 async/await is also supported:
 
 ```js
-async function plugin(server, opts) {
-  await sleep(10);
+async function plugin (server, opts) {
+  await sleep(10)
 }
 
-app.use(plugin);
+app.use(plugin)
 ```
 
 `use` returns the instance on which `use` is called, to support a chainable API.
@@ -183,9 +176,9 @@ app.use(plugin);
 A function that returns the options argument instead of an object is supported as well:
 
 ```js
-function plugin(server, opts, done) {
-  console.log(opts); // Evaluates to: { hello: 'world' }
-  done();
+function plugin (server, opts, done) {
+  console.log(opts) // Evaluates to: { hello: 'world' }
+  done()
 }
 
 /**
@@ -194,40 +187,37 @@ function plugin(server, opts, done) {
  */
 const func = parent => {
   return {
-    hello: "world"
-  };
-};
+    hello: 'world'
+  }
+}
 
-app.use(plugin, func);
+app.use(plugin, func)
 ```
 
 This is useful in cases where an injected variable from a plugin needs to be made available to another.
 
----
-
+-------------------------------------------------------
 <a name="error-handling"></a>
-
 #### Error handling
 
 In order to handle errors in the loading plugins, you must use the
 `.ready()` method, like so:
 
 ```js
-app.use(function(instance, opts, done) {
-  done(new Error("error"));
-}, opts);
+app.use(function (instance, opts, done) {
+  done(new Error('error'))
+}, opts)
 
-app.ready(function(err) {
-  if (err) throw err;
-});
+app.ready(function (err) {
+  if (err) throw err
+})
 ```
 
 When an error happens, the loading of plugins will stop until there is
 an [`after`](#after) callback specified. Otherwise, it will be handled
 in [`ready`](#ready).
 
----
-
+-------------------------------------------------------
 <a name="after"></a>
 
 ### app.after(func(error, [context], [done]))
@@ -236,7 +226,6 @@ Calls a function after all the previously defined plugins are loaded, including
 all their dependencies. The `'start'` event is not emitted yet.
 
 The callback changes basing on the parameters your are giving:
-
 1. If no parameter is given to the callback and there is an error, that error will be passed to the next error handler.
 2. If one parameter is given to the callback, that parameter will be the `error` object.
 3. If two parameters are given to the callback, the first will be the `error` object, the second will be the `done` callback.
@@ -286,8 +275,7 @@ app.after(async function () {
 
 Returns the instance on which `after` is called, to support a chainable API.
 
----
-
+-------------------------------------------------------
 <a name="ready"></a>
 
 ### app.ready([func(error, [context], [done])])
@@ -295,13 +283,12 @@ Returns the instance on which `after` is called, to support a chainable API.
 Calls a function after all the plugins and `after` call are completed, but before `'start'` is emitted. `ready` callbacks are executed one at a time.
 
 The callback changes basing on the parameters your are giving:
-
 1. If no parameter is given to the callback and there is an error, that error will be passed to the next error handler.
 2. If one parameter is given to the callback, that parameter will be the `error` object.
 3. If two parameters are given to the callback, the first will be the `error` object, the second will be the `done` callback.
 4. If three parameters are given to the callback, the first will be the `error` object, the second will be the top level `context` unless you have specified both server and override, in that case the `context` will be what the override returns, and the third the `done` callback.
 
-If no callback is provided `ready` will return a Promise that is resolved or rejected once plugins and `after` calls are completed. On success `context` is provided to the `.then` callback, if an error occurs it is provided to the `.catch` callback.
+If no callback is provided `ready` will return a Promise that is resolved or rejected once plugins and `after` calls are completed.  On success `context` is provided to the `.then` callback, if an error occurs it is provided to the `.catch` callback.
 
 ```js
 const server = {}
@@ -352,8 +339,7 @@ The callback form of this function has no return value.
 If `autostart: false` is passed as an option, calling `.ready()`  will
 also start the boot sequence.
 
----
-
+-------------------------------------------------------
 <a name="start"></a>
 
 ### app.start()
@@ -361,8 +347,7 @@ also start the boot sequence.
 Start the boot sequence, if it was not started yet.
 Returns the `app` instance.
 
----
-
+-------------------------------------------------------
 <a name="express"></a>
 
 ### avvio.express(app)
@@ -370,18 +355,17 @@ Returns the `app` instance.
 Same as:
 
 ```js
-const app = express();
-const avvio = require("avvio");
+const app = express()
+const avvio = require('avvio')
 
 avvio(app, {
   expose: {
-    use: "load"
+    use: 'load'
   }
-});
+})
 ```
 
----
-
+-------------------------------------------------------
 <a name="override"></a>
 
 ### app.override(server, plugin, options)
@@ -391,47 +375,44 @@ It allows the creation of an inheritance chain for the server instances.
 The first parameter is the server instance and the second is the plugin function while the third is the options object that you give to use.
 
 ```js
-const assert = require("assert");
-const server = { count: 0 };
-const app = require("avvio")(server);
+const assert = require('assert')
+const server = { count: 0 }
+const app = require('avvio')(server)
 
-console.log(app !== server, "override must be set on the Avvio instance");
+console.log(app !== server, 'override must be set on the Avvio instance')
 
-app.override = function(s, fn, opts) {
+app.override = function (s, fn, opts) {
   // create a new instance with the
   // server as the prototype
-  const res = Object.create(s);
-  res.count = res.count + 1;
+  const res = Object.create(s)
+  res.count = res.count + 1
 
-  return res;
-};
+  return res
+}
 
-app.use(function first(s1, opts, cb) {
-  assert(s1 !== server);
-  assert(server.isPrototypeOf(s1));
-  assert(s1.count === 1);
-  s1.use(second);
-  cb();
+app.use(function first (s1, opts, cb) {
+  assert(s1 !== server)
+  assert(server.isPrototypeOf(s1))
+  assert(s1.count === 1)
+  s1.use(second)
+  cb()
 
-  function second(s2, opts, cb) {
-    assert(s2 !== s1);
-    assert(s1.isPrototypeOf(s2));
-    assert(s2.count === 2);
-    cb();
+  function second (s2, opts, cb) {
+    assert(s2 !== s1)
+    assert(s1.isPrototypeOf(s2))
+    assert(s2.count === 2)
+    cb()
   }
-});
+})
 ```
-
----
+-------------------------------------------------------
 
 <a name="onClose"></a>
-
 ### app.onClose(func([context], [done]))
 
 Registers a new callback that will be fired once then `close` api is called.
 
 The callback changes basing on the parameters your are giving:
-
 1. If one parameter is given to the callback, that parameter will be the `context`.
 2. If zero or one parameter is given, the callback may return a promise
 3. If two parameters are given to the callback, the first will be the top level `context` unless you have specified both server and override, in that case the `context` will be what the override returns, the second will be the `done` callback.
@@ -471,16 +452,14 @@ If the callback returns a promise, the next onClose callback and the close callb
 `done` must be called only once.
 Returns the instance on which `onClose` is called, to support a chainable API.
 
----
+-------------------------------------------------------
 
 <a name="close"></a>
-
 ### app.close(func(error, [context], [done]))
 
 Starts the shutdown procedure, the callback is called once all the registered callbacks with `onClose` has been executed.
 
 The callback changes based on the parameters your are giving:
-
 1. If one parameter is given to the callback, that parameter will be the `error` object.
 2. If two parameters are given to the callback, the first will be the `error` object, the second will be the `done` callback.
 3. If three parameters are given to the callback, the first will be the `error` object, the second will be the top level `context` unless you have specified both server and override, in that case the `context` will be what the override returns, and the third the `done` callback.
@@ -521,7 +500,7 @@ app.close()
 
 `done` must be called only once.
 
----
+-------------------------------------------------------
 
 ## Acknowledgements
 
@@ -531,5 +510,5 @@ This project was kindly sponsored by [nearForm](http://nearform.com).
 
 Copyright Matteo Collina 2016-2017, Licensed under [MIT][].
 
-[mit]: ./LICENSE
+[MIT]: ./LICENSE
 [example]: ./example.js

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "debug": "^4.0.0",
+    "fast-deepclone": "^1.0.1",
     "fastq": "^1.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   },
   "dependencies": {
     "debug": "^4.0.0",
-    "fast-deepclone": "^1.0.1",
     "fastq": "^1.6.0"
   }
 }

--- a/plugin.js
+++ b/plugin.js
@@ -2,6 +2,7 @@
 
 const fastq = require('fastq')
 const debug = require('debug')('avvio')
+const deepClone = require('fast-deepclone')
 const CODE_PLUGIN_TIMEOUT = 'ERR_AVVIO_PLUGIN_TIMEOUT'
 
 function getName (func) {
@@ -25,9 +26,9 @@ function getName (func) {
   return func.toString().split('\n').slice(0, 2).map(s => s.trim()).join(' -- ')
 }
 
-function Plugin (parent, func, opts, isAfter, timeout) {
+function Plugin (parent, func, optsOrFunc, isAfter, timeout) {
   this.func = func
-  this.opts = opts
+  this.opts = isFunction(optsOrFunc) ? deepClone(optsOrFunc()) : optsOrFunc
   this.deferred = false
   this.onFinish = null
   this.parent = parent
@@ -172,6 +173,11 @@ function loadPlugin (toLoad, cb) {
 }
 
 function noop () {}
+
+// Checks if a variable is a function, taken from https://stackoverflow.com/a/7356528
+function isFunction (functionToCheck) {
+  return functionToCheck && {}.toString.call(functionToCheck) === '[object Function]'
+}
 
 module.exports = Plugin
 module.exports.loadPlugin = loadPlugin

--- a/plugin.js
+++ b/plugin.js
@@ -28,7 +28,7 @@ function getName (func) {
 
 function Plugin (parent, func, optsOrFunc, isAfter, timeout) {
   this.func = func
-  this.opts = isFunction(optsOrFunc) ? deepClone(optsOrFunc()) : optsOrFunc
+  this.opts = optsOrFunc instanceof Function ? deepClone(optsOrFunc()) : optsOrFunc
   this.deferred = false
   this.onFinish = null
   this.parent = parent
@@ -173,11 +173,6 @@ function loadPlugin (toLoad, cb) {
 }
 
 function noop () {}
-
-// Checks if a variable is a function, taken from https://stackoverflow.com/a/7356528
-function isFunction (functionToCheck) {
-  return functionToCheck && {}.toString.call(functionToCheck) === '[object Function]'
-}
 
 module.exports = Plugin
 module.exports.loadPlugin = loadPlugin

--- a/plugin.js
+++ b/plugin.js
@@ -27,7 +27,7 @@ function getName (func) {
 
 function Plugin (parent, func, optsOrFunc, isAfter, timeout) {
   this.func = func
-  this.opts = typeof optsOrFunc === 'function' ? optsOrFunc(parent) : optsOrFunc
+  this.opts = typeof optsOrFunc === 'function' ? optsOrFunc.bind(optsOrFunc, parent) : optsOrFunc
   this.deferred = false
   this.onFinish = null
   this.parent = parent
@@ -46,6 +46,8 @@ function Plugin (parent, func, optsOrFunc, isAfter, timeout) {
 }
 
 Plugin.prototype.exec = function (server, cb) {
+  this.opts = typeof this.opts === 'function' ? this.opts() : this.opts
+
   const func = this.func
   var completed = false
   var name = this.name

--- a/plugin.js
+++ b/plugin.js
@@ -2,7 +2,6 @@
 
 const fastq = require('fastq')
 const debug = require('debug')('avvio')
-const deepClone = require('fast-deepclone')
 const CODE_PLUGIN_TIMEOUT = 'ERR_AVVIO_PLUGIN_TIMEOUT'
 
 function getName (func) {
@@ -28,7 +27,7 @@ function getName (func) {
 
 function Plugin (parent, func, optsOrFunc, isAfter, timeout) {
   this.func = func
-  this.opts = optsOrFunc instanceof Function ? deepClone(optsOrFunc()) : optsOrFunc
+  this.opts = typeof optsOrFunc === 'function' ? optsOrFunc() : optsOrFunc
   this.deferred = false
   this.onFinish = null
   this.parent = parent

--- a/plugin.js
+++ b/plugin.js
@@ -27,7 +27,7 @@ function getName (func) {
 
 function Plugin (parent, func, optsOrFunc, isAfter, timeout) {
   this.func = func
-  this.opts = typeof optsOrFunc === 'function' ? optsOrFunc() : optsOrFunc
+  this.opts = typeof optsOrFunc === 'function' ? optsOrFunc(parent) : optsOrFunc
   this.deferred = false
   this.onFinish = null
   this.parent = parent

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -148,19 +148,23 @@ test('boot a plugin with options', (t) => {
 })
 
 test('boot a plugin with a function that returns the options', (t) => {
-  t.plan(3)
+  t.plan(4)
 
   const server = {}
   const app = boot(server)
   const myOpts = {
     hello: 'world'
   }
+  const myOptsAsFunc = parent => {
+    t.strictEqual(parent, app)
+    return myOpts
+  }
 
   app.use(function (s, opts, done) {
     t.equal(s, server, 'the first argument is the server')
     t.deepEqual(opts, myOpts, 'passed options via function')
     done()
-  }, () => myOpts)
+  }, myOptsAsFunc)
 
   app.on('start', () => {
     t.pass('booted')

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -147,6 +147,50 @@ test('boot a plugin with options', (t) => {
   })
 })
 
+test('boot a plugin with a function that returns the options', (t) => {
+  t.plan(3)
+
+  const server = {}
+  const app = boot(server)
+  const myOpts = {
+    hello: 'world'
+  }
+
+  app.use(function (s, opts, done) {
+    t.equal(s, server, 'the first argument is the server')
+    t.deepEqual(opts, myOpts, 'passed options via function')
+    done()
+  }, () => myOpts)
+
+  app.on('start', () => {
+    t.pass('booted')
+  })
+})
+
+test('boot a plugin with a function that returns options without referencing the returned object', (t) => {
+  t.plan(4)
+
+  const server = {}
+  const app = boot(server)
+  const myOpts = {
+    hello: {
+      there: 'world'
+    }
+  }
+
+  app.use(function (s, opts, done) {
+    t.equal(s, server, 'the first argument is the server')
+    t.deepEqual(opts, myOpts, 'passed options')
+    myOpts.hello.there = 'mundo'
+    t.notEqual(opts.hello.there, myOpts.hello.there, 'created new option references')
+    done()
+  }, () => myOpts)
+
+  app.on('start', () => {
+    t.pass('booted')
+  })
+})
+
 test('throw on non-function use', (t) => {
   t.plan(1)
   const app = boot()

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -167,30 +167,6 @@ test('boot a plugin with a function that returns the options', (t) => {
   })
 })
 
-test('boot a plugin with a function that returns options without referencing the returned object', (t) => {
-  t.plan(4)
-
-  const server = {}
-  const app = boot(server)
-  const myOpts = {
-    hello: {
-      there: 'world'
-    }
-  }
-
-  app.use(function (s, opts, done) {
-    t.equal(s, server, 'the first argument is the server')
-    t.deepEqual(opts, myOpts, 'passed options')
-    myOpts.hello.there = 'mundo'
-    t.notEqual(opts.hello.there, myOpts.hello.there, 'created new option references')
-    done()
-  }, () => myOpts)
-
-  app.on('start', () => {
-    t.pass('booted')
-  })
-})
-
 test('throw on non-function use', (t) => {
   t.plan(1)
   const app = boot()

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -157,12 +157,17 @@ test('boot a plugin with a function that returns the options', (t) => {
   }
   const myOptsAsFunc = parent => {
     t.strictEqual(parent, app)
-    return myOpts
+    return parent.myOpts
   }
 
   app.use(function (s, opts, done) {
+    app.myOpts = opts
+    done()
+  }, myOpts)
+
+  app.use(function (s, opts, done) {
     t.equal(s, server, 'the first argument is the server')
-    t.deepEqual(opts, myOpts, 'passed options via function')
+    t.deepEqual(opts, myOpts, 'passed options via function accessing parent injected variable')
     done()
   }, myOptsAsFunc)
 


### PR DESCRIPTION
Attempting [fastify/fastify#1489](https://github.com/fastify/fastify/issues/1489)

An external dependency `fast-deepclone` was added as `Object.assign({}, variable)` wouldn't suit our purpose due to it being a shallow copy and thus passing by reference. The operational overhead is minimal thanks to the module being coded natively in C++. Its license is [MIT](https://github.com/scottinet/fast-deepclone/blob/master/LICENSE) which I believe is compatibly with this project's license.

Added unit tests as well. Let me know your thoughts.