### PR TITLE
Fixed function as option variable reference issue of PR82

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,13 @@ app.use(plugin)
 A function that returns the options argument instead of an object is supported as well:
 
 ```js
-function plugin (server, opts, done) {
-  console.log(opts) // Evaluates to: { hello: 'world' }
+function first (server, opts, done) {
+  server.foo = 'bar'
+  done()
+}
+
+function second (server, opts, done) {
+  console.log(opts.foo === 'bar') // Evaluates to true
   done()
 }
 
@@ -187,11 +192,12 @@ function plugin (server, opts, done) {
  */
 const func = parent => {
   return {
-    hello: 'world'
+    foo: parent.foo
   }
 }
 
-app.use(plugin, func)
+app.use(first)
+app.use(second, func)
 ```
 
 This is useful in cases where an injected variable from a plugin needs to be made available to another.

--- a/plugin.js
+++ b/plugin.js
@@ -27,7 +27,7 @@ function getName (func) {
 
 function Plugin (parent, func, optsOrFunc, isAfter, timeout) {
   this.func = func
-  this.opts = typeof optsOrFunc === 'function' ? optsOrFunc.bind(null, parent) : optsOrFunc
+  this.opts = optsOrFunc
   this.deferred = false
   this.onFinish = null
   this.parent = parent
@@ -46,8 +46,6 @@ function Plugin (parent, func, optsOrFunc, isAfter, timeout) {
 }
 
 Plugin.prototype.exec = function (server, cb) {
-  this.opts = typeof this.opts === 'function' ? this.opts() : this.opts
-
   const func = this.func
   var completed = false
   var name = this.name
@@ -64,6 +62,8 @@ Plugin.prototype.exec = function (server, cb) {
     debug('override errored', name)
     return cb(err)
   }
+
+  this.opts = typeof this.opts === 'function' ? this.opts(this.server) : this.opts
 
   debug('exec', name)
 

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -156,12 +156,12 @@ test('boot a plugin with a function that returns the options', (t) => {
     hello: 'world'
   }
   const myOptsAsFunc = parent => {
-    t.strictEqual(parent, app)
+    t.strictEqual(parent, server)
     return parent.myOpts
   }
 
   app.use(function (s, opts, done) {
-    app.myOpts = opts
+    s.myOpts = opts
     done()
   }, myOpts)
 

--- a/test/override.test.js
+++ b/test/override.test.js
@@ -254,3 +254,38 @@ test('override can receive options object', (t) => {
     cb()
   }, options)
 })
+
+test('override can receive options function', (t) => {
+  t.plan(8)
+
+  const server = { my: 'server' }
+  const options = { hello: 'world' }
+  const app = boot(server)
+
+  app.override = function (s, fn, opts) {
+    t.equal(s, server)
+    if (typeof opts !== 'function') {
+      t.deepEqual(opts, options)
+    }
+
+    const res = Object.create(s)
+    res.b = 42
+    res.bar = 'world'
+
+    return res
+  }
+
+  app.use(function first (s, opts, cb) {
+    t.notEqual(s, server)
+    t.ok(server.isPrototypeOf(s))
+    s.foo = 'bar'
+    cb()
+  }, options)
+
+  app.use(function second (s, opts, cb) {
+    t.notOk(s.foo)
+    t.deepEqual(opts, { hello: 'world' })
+    t.ok(server.isPrototypeOf(s))
+    cb()
+  }, p => ({ hello: p.bar }))
+})


### PR DESCRIPTION
Hello again,

It appears the original PR I had made was passing in the wrong variable to the function that was passed in as `options`. In this PR, I have updated the previous test case and added a new one for `override`. 

In short, instead of binding the `parent` instance of the plugin during declaration and evaluating it during execution, we directly evaluate the function during execution after the `override` function has been called by passing `this.server` to it as an argument. This should provide more consistent and expected results from the change.

Also added slight documentation change to showcase the default behavior.

Let me know your thoughts.

Kind regards,
Alex P.