### PR TITLE
Do not crash within after when registering a plugin

### DIFF
--- a/boot.js
+++ b/boot.js
@@ -204,14 +204,12 @@ Boot.prototype._addPlugin = function (plugin, opts, isAfter) {
   const current = this._current[0]
 
   const obj = new Plugin(this, plugin, opts, isAfter)
-  if (!isAfter) {
-    obj.once('start', (serverName, funcName, time) => {
-      const nodeId = this.pluginTree.start(current.name, funcName, time)
-      obj.once('loaded', (serverName, funcName, time) => {
-        this.pluginTree.stop(nodeId, time)
-      })
+  obj.once('start', (serverName, funcName, time) => {
+    const nodeId = this.pluginTree.start(current.name, funcName, time)
+    obj.once('loaded', (serverName, funcName, time) => {
+      this.pluginTree.stop(nodeId, time)
     })
-  }
+  })
 
   if (current.loaded) {
     throw new Error(`Impossible to load "${obj.name}" plugin because the parent "${current.name}" was already loaded`)

--- a/example.js
+++ b/example.js
@@ -26,7 +26,7 @@ avvio
       .use(b)
     setTimeout(cb, 42)
   })
-  .after((err, cb) => {
+  .after(function (err, cb) {
     if (err) {
       console.log('something bad happened')
       console.log(err)
@@ -35,14 +35,7 @@ avvio
     cb()
   })
   .use(duplicate, { count: 4 })
-  .use(third, (err) => {
-    if (err) {
-      console.log('something bad happened')
-      console.log(err)
-    }
-
-    console.log('third plugin loaded')
-  })
+  .use(third)
   .ready(function (err) {
     if (err) {
       throw err

--- a/test/after-use-after.test.js
+++ b/test/after-use-after.test.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const t = require('tap')
+const boot = require('..')
+const app = {}
+
+boot(app)
+
+t.plan(6)
+
+app.use(function (f, opts, cb) {
+  cb()
+}).after(() => {
+  t.pass('this is just called')
+
+  app.use(function (f, opts, cb) {
+    t.pass('this is just called')
+    cb()
+  })
+}).after(function () {
+  t.pass('this is just called')
+  app.use(function (f, opts, cb) {
+    t.pass('this is just called')
+    cb()
+  })
+}).after(function (err, cb) {
+  t.pass('this is just called')
+  cb(err)
+})
+
+app.ready().then(() => {
+  t.pass('ready')
+}).catch(() => {
+  t.fail('this should not be called')
+})


### PR DESCRIPTION
This revert a bit done what was done in https://github.com/mcollina/avvio/pull/81 by @Eomm. We have to report the `after` calls to the time tracker, otherwise we lose the trace of what we have loaded. However, this pollutes the `.toJSON()` and pretty-print representation of this.

I think we should land this as patch asap, and then find out what to do with the pretty print.

Fixes: https://github.com/fastify/fastify/issues/1781