### PR TITLE
fix test pretty print after

### DIFF
--- a/test/pretty-print.test.js
+++ b/test/pretty-print.test.js
@@ -4,7 +4,7 @@ const test = require('tap').test
 const boot = require('..')
 
 test('pretty print', t => {
-  t.plan(14)
+  t.plan(16)
 
   const app = boot()
   app
@@ -12,7 +12,7 @@ test('pretty print', t => {
     .use(duplicate, { count: 3 })
     .use(second)
     .use(duplicate, { count: 2 })
-    .use(third)
+    .use(third).after(after)
     .use(duplicate, { count: 1 })
 
   const linesExpected = [ /bound root \d+ ms/,
@@ -26,6 +26,7 @@ test('pretty print', t => {
     /│ └─┬ duplicate \d+ ms/,
     /│ {3}└── duplicate \d+ ms/,
     /├── third \d+ ms/,
+    /├── bound _after \d+ ms/,
     /└─┬ duplicate \d+ ms/,
     / {2}└── duplicate \d+ ms/,
     ''
@@ -33,7 +34,12 @@ test('pretty print', t => {
 
   app.on('preReady', function show () {
     const print = app.prettyPrint()
-    print.split('\n').forEach((l, i) => {
+    const lines = print.split('\n')
+
+    console.log(print)
+
+    t.equals(lines.length, linesExpected.length)
+    lines.forEach((l, i) => {
       t.match(l, linesExpected[i])
     })
   })
@@ -46,6 +52,9 @@ test('pretty print', t => {
   }
   function third (s, opts, done) {
     done()
+  }
+  function after (err, cb) {
+    cb(err)
   }
 
   function duplicate (instance, opts, cb) {

--- a/test/pretty-print.test.js
+++ b/test/pretty-print.test.js
@@ -4,13 +4,13 @@ const test = require('tap').test
 const boot = require('..')
 
 test('pretty print', t => {
-  t.plan(18)
+  t.plan(19)
 
   const app = boot()
   app
     .use(first)
     .use(duplicate, { count: 3 })
-    .use(second).after(after).after(after)
+    .use(second).after(afterUse).after(after)
     .use(duplicate, { count: 2 })
     .use(third).after(after)
     .use(duplicate, { count: 1 })
@@ -22,7 +22,8 @@ test('pretty print', t => {
     /│ {3}└─┬ duplicate \d+ ms/,
     /│ {5}└── duplicate \d+ ms/,
     /├── second \d+ ms/,
-    /├── bound _after \d+ ms/,
+    /├─┬ bound _after \d+ ms/,
+    /│ └── afterInsider \d+ ms/,
     /├── bound _after \d+ ms/,
     /├─┬ duplicate \d+ ms/,
     /│ └─┬ duplicate \d+ ms/,
@@ -55,6 +56,14 @@ test('pretty print', t => {
   }
   function after (err, cb) {
     cb(err)
+  }
+  function afterUse (err, cb) {
+    app.use(afterInsider)
+    cb(err)
+  }
+
+  function afterInsider (s, opts, done) {
+    done()
   }
 
   function duplicate (instance, opts, cb) {

--- a/test/pretty-print.test.js
+++ b/test/pretty-print.test.js
@@ -4,13 +4,13 @@ const test = require('tap').test
 const boot = require('..')
 
 test('pretty print', t => {
-  t.plan(16)
+  t.plan(18)
 
   const app = boot()
   app
     .use(first)
     .use(duplicate, { count: 3 })
-    .use(second)
+    .use(second).after(after).after(after)
     .use(duplicate, { count: 2 })
     .use(third).after(after)
     .use(duplicate, { count: 1 })
@@ -22,6 +22,8 @@ test('pretty print', t => {
     /│ {3}└─┬ duplicate \d+ ms/,
     /│ {5}└── duplicate \d+ ms/,
     /├── second \d+ ms/,
+    /├── bound _after \d+ ms/,
+    /├── bound _after \d+ ms/,
     /├─┬ duplicate \d+ ms/,
     /│ └─┬ duplicate \d+ ms/,
     /│ {3}└── duplicate \d+ ms/,
@@ -35,8 +37,6 @@ test('pretty print', t => {
   app.on('preReady', function show () {
     const print = app.prettyPrint()
     const lines = print.split('\n')
-
-    console.log(print)
 
     t.equals(lines.length, linesExpected.length)
     lines.forEach((l, i) => {


### PR DESCRIPTION
Since the test wasn't failing due #88, I would add the `after` call in the pretty tests.

This is the output:

```
bound root 195 ms
├── first 0 ms
├─┬ duplicate 86 ms
│ └─┬ duplicate 64 ms
│   └─┬ duplicate 42 ms
│     └── duplicate 21 ms
├── second 0 ms
├─┬ bound _after 0 ms
│ └── afterInsider 0 ms
├── bound _after 0 ms
├─┬ duplicate 63 ms
│ └─┬ duplicate 41 ms
│   └── duplicate 21 ms
├── third 0 ms
├── bound _after 0 ms
└─┬ duplicate 41 ms
  └── duplicate 21 ms
```

that is not good for fastify because there is always a `bound _after` entry for each `register` call.

I will try to fix this behaviour in separate PR