### PR TITLE
Basic support for promise plugins / esm with import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 
 node_js:
+  - "13"
+  - "12"
   - "10"
   - "8"
   - "6"

--- a/README.md
+++ b/README.md
@@ -204,6 +204,15 @@ app.use(second, func)
 
 This is useful in cases where an injected variable from a plugin needs to be made available to another.
 
+It is also possible to use [esm](https://nodejs.org/api/esm.html) with `import('./file.mjs')`:
+
+```js
+import boot from 'avvio'
+
+const app = boot()
+app.use(import('./fixtures/esm.mjs'))
+```
+
 -------------------------------------------------------
 <a name="error-handling"></a>
 #### Error handling

--- a/boot.js
+++ b/boot.js
@@ -187,7 +187,6 @@ function assertPlugin (plugin) {
 
 // load a plugin
 Boot.prototype.use = function (plugin, opts) {
-  assertPlugin(plugin)
   this._addPlugin(plugin, opts, false)
 
   return this

--- a/boot.js
+++ b/boot.js
@@ -179,21 +179,22 @@ Boot.prototype.override = function (server, func, opts) {
   return server
 }
 
+function assertPlugin (plugin) {
+  if (!(plugin && (typeof plugin === 'function' || typeof plugin.then === 'function'))) {
+    throw new Error('plugin must be a function or a promise')
+  }
+}
+
 // load a plugin
 Boot.prototype.use = function (plugin, opts) {
-  if (typeof plugin === 'function') {
-    this._addPlugin(plugin, opts, false)
-  } else {
-    throw new Error('plugin must be a function')
-  }
+  assertPlugin(plugin)
+  this._addPlugin(plugin, opts, false)
 
   return this
 }
 
 Boot.prototype._addPlugin = function (plugin, opts, isAfter) {
-  if (typeof plugin !== 'function') {
-    throw new Error('plugin must be a function')
-  }
+  assertPlugin(plugin)
   opts = opts || {}
 
   if (this.booted) {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "@types/node": "^10.9.1",
     "express": "^4.16.3",
     "pre-commit": "^1.2.2",
-    "standard": "^12.0.1",
+    "semver": "^6.3.0",
+    "standard": "^14.0.0",
     "tap": "^12.0.0",
     "then-sleep": "^1.0.1",
     "typescript": "^3.1.1"

--- a/plugin.js
+++ b/plugin.js
@@ -170,6 +170,9 @@ Plugin.prototype.finish = function (err, cb) {
 function loadPlugin (toLoad, cb) {
   if (typeof toLoad.func.then === 'function') {
     toLoad.func.then((fn) => {
+      if (typeof fn.default === 'function') {
+        fn = fn.default
+      }
       toLoad.func = fn
       loadPlugin.call(this, toLoad, cb)
     }, cb)

--- a/plugin.js
+++ b/plugin.js
@@ -168,7 +168,16 @@ Plugin.prototype.finish = function (err, cb) {
 
 // loads a plugin
 function loadPlugin (toLoad, cb) {
+  if (typeof toLoad.func.then === 'function') {
+    toLoad.func.then((fn) => {
+      toLoad.func = fn
+      loadPlugin.call(this, toLoad, cb)
+    }, cb)
+    return
+  }
+
   const last = this._current[0]
+
   // place the plugin at the top of _current
   this._current.unshift(toLoad)
 

--- a/test/async-await.js
+++ b/test/async-await.js
@@ -1,5 +1,7 @@
 'use strict'
 
+/* eslint no-prototype-builtins: off */
+
 const test = require('tap').test
 const sleep = require('then-sleep')
 
@@ -282,7 +284,6 @@ test('skip override with promise', (t) => {
   const app = boot(server)
 
   app.override = function (s, func) {
-    console.log(func.toString())
     t.pass('override called')
 
     if (func[Symbol.for('skip-override')]) {

--- a/test/chainable.test.js
+++ b/test/chainable.test.js
@@ -6,7 +6,7 @@ const boot = require('..')
 test('chainable standalone', (t) => {
   t.plan(5)
 
-  let readyResult = boot()
+  const readyResult = boot()
     .use(function (ctx, opts, done) {
       t.pass('1st plugin')
       done()
@@ -26,7 +26,7 @@ test('chainable automatically binded', (t) => {
   const app = {}
   boot(app)
 
-  let readyResult = app
+  const readyResult = app
     .use(function (ctx, opts, done) {
       t.pass('1st plugin')
       done()

--- a/test/esm.mjs
+++ b/test/esm.mjs
@@ -1,0 +1,14 @@
+import tap from 'tap'
+import boot from '../boot.js'
+
+const { test } = tap
+
+test('support import', async (t) => {
+  const app = boot()
+
+  app.use(import('./fixtures/esm.mjs'))
+
+  await app.ready()
+
+  t.is(app.loaded, true)
+})

--- a/test/esm.test.js
+++ b/test/esm.test.js
@@ -1,0 +1,15 @@
+'use strict'
+
+const tap = require('tap')
+const semver = require('semver')
+
+if (semver.lt(process.versions.node, '13.3.0')) {
+  tap.pass('Skip because Node version <= 13.3.0')
+  tap.end()
+} else {
+  import('./esm.mjs').catch((err) => {
+    process.nextTick(() => {
+      throw err
+    })
+  })
+}

--- a/test/fixtures/esm.mjs
+++ b/test/fixtures/esm.mjs
@@ -1,0 +1,3 @@
+export default async function (app) {
+  app.loaded = true
+}

--- a/test/override.test.js
+++ b/test/override.test.js
@@ -1,5 +1,7 @@
 'use strict'
 
+/* eslint no-prototype-builtins: off */
+
 const test = require('tap').test
 const boot = require('..')
 

--- a/test/pretty-print.test.js
+++ b/test/pretty-print.test.js
@@ -15,7 +15,7 @@ test('pretty print', t => {
     .use(third).after(after)
     .use(duplicate, { count: 1 })
 
-  const linesExpected = [ /bound root \d+ ms/,
+  const linesExpected = [/bound root \d+ ms/,
     /├── first \d+ ms/,
     /├─┬ duplicate \d+ ms/,
     /│ └─┬ duplicate \d+ ms/,


### PR DESCRIPTION
The goal of this PR is to add support for `import()` statements for plugins. In this way, if we want to load an ESM, Node could potentially load all of them in parallel while we process one at a time.

In fastify lingo:

```js
app.register(import('path/to/plugin'), opts)
```

The way this is implemented in this PR is to add support for promises: import() returns a promise.

This needs:

* [x] some more testing with latest Node 13
* [x] docs