### PR TITLE
Await fixes

### DIFF
--- a/test/after-and-ready.test.js
+++ b/test/after-and-ready.test.js
@@ -753,3 +753,37 @@ test('preReady event (errored)', (t) => {
     t.is(order.shift(), 3)
   })
 })
+
+test('after return self', (t) => {
+  t.plan(6)
+
+  const app = boot()
+  let pluginLoaded = false
+  let afterCalled = false
+  let second = false
+
+  app.use(function (s, opts, done) {
+    t.notOk(afterCalled, 'after not called')
+    pluginLoaded = true
+    done()
+  })
+
+  app.after(function () {
+    t.ok(pluginLoaded, 'afterred!')
+    afterCalled = true
+    // happens with after(() => app.use(..))
+    return app
+  })
+
+  app.use(function (s, opts, done) {
+    t.ok(afterCalled, 'after called')
+    second = true
+    done()
+  })
+
+  app.on('start', () => {
+    t.ok(afterCalled, 'after called')
+    t.ok(pluginLoaded, 'plugin loaded')
+    t.ok(second, 'second plugin loaded')
+  })
+})

--- a/test/await-after.test.js
+++ b/test/await-after.test.js
@@ -27,6 +27,27 @@ test('await after - nested plugins with same tick callbacks', async (t) => {
   t.pass('reachable')
 })
 
+test('await after without server', async (t) => {
+  const app = boot()
+
+  let secondLoaded = false
+
+  app.use(async (app) => {
+    t.pass('plugin init')
+    app.use(async () => {
+      t.pass('plugin2 init')
+      await sleep(1)
+      secondLoaded = true
+    })
+  })
+  await app.after()
+  t.pass('reachable')
+  t.is(secondLoaded, true)
+
+  await app.ready()
+  t.pass('reachable')
+})
+
 test('await after - nested plugins with future tick callbacks', async (t) => {
   const app = {}
   boot(app)
@@ -308,4 +329,17 @@ test('without autostart and with override', async (t) => {
   })
 
   await app.ready()
+})
+
+test('stop processing after errors', async (t) => {
+  const app = boot()
+
+  try {
+    await app.use(async function first (app) {
+      t.pass('first should be loaded')
+      throw new Error('kaboom')
+    })
+  } catch (e) {
+    t.is(e.message, 'kaboom')
+  }
 })


### PR DESCRIPTION
This PR changes substantially how our `await app.register()` and `await app.after()` works. Essentially, it's impossible to "skip error and continue", as we were doing before. Instead, this makes the promise reject.

Fixes #93 
Fixes #94