### PR TITLE
Actually rejects when await app.after() or await app.register()

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -145,6 +145,7 @@ Plugin.prototype._pushToAsyncQ = function (fn) {
   debug('_pushToAsyncQ', this.name)
   if (this.asyncQ.length() === 0) {
     this.server.after((err, cb) => {
+      this._error = err
       this.q.pause()
       debug('resuming asyncQ', this.name)
       this.asyncQ.resume()

--- a/test/after-pass-through.test.js
+++ b/test/after-pass-through.test.js
@@ -8,15 +8,17 @@ boot(app)
 
 t.plan(5)
 
+const e = new Error('kaboom')
+
 app.use(function (f, opts) {
-  return Promise.reject(new Error('kaboom'))
+  return Promise.reject(e)
 }).after(function (err, cb) {
-  t.pass('this is just called')
+  t.is(err, e)
   cb(err)
 }).after(function () {
   t.pass('this is just called')
 }).after(function (err, cb) {
-  t.pass('this is just called')
+  t.is(err, e)
   cb(err)
 })
 

--- a/test/await-after.test.js
+++ b/test/await-after.test.js
@@ -134,55 +134,59 @@ test('await after - promise returning function plugins + promise chaining', asyn
   t.pass('reachable')
 })
 
-test('await after - error handling, async throw', async (t) => {
+test('await after - error handling, async throw', { only: true }, async (t) => {
   const app = {}
   boot(app)
 
-  t.plan(1)
+  t.plan(2)
+
+  const e = new Error('kaboom')
 
   app.use(async (f, opts) => {
     throw Error('kaboom')
   })
 
-  await app.after()
+  await t.rejects(app.after(), e)
 
-  t.rejects(() => app.ready(), Error('kaboom'))
+  await t.rejects(() => app.ready(), Error('kaboom'))
 })
 
 test('await after - error handling, async throw, nested', async (t) => {
   const app = {}
   boot(app)
 
-  t.plan(1)
+  t.plan(2)
+
+  const e = new Error('kaboom')
 
   app.use(async (f, opts) => {
     app.use(async (f, opts) => {
-      throw Error('kaboom')
+      throw e
     })
   })
-  await app.after()
 
-  t.rejects(() => app.ready(), Error('kaboom'))
+  await t.rejects(app.after())
+  await t.rejects(() => app.ready(), e)
 })
 
 test('await after - error handling, same tick cb err', async (t) => {
   const app = {}
   boot(app)
 
-  t.plan(1)
+  t.plan(2)
 
   app.use((f, opts, cb) => {
     cb(Error('kaboom'))
   })
-  await app.after()
-  t.rejects(() => app.ready(), Error('kaboom'))
+  await t.rejects(app.after())
+  await t.rejects(app.ready(), Error('kaboom'))
 })
 
 test('await after - error handling, same tick cb err, nested', async (t) => {
   const app = {}
   boot(app)
 
-  t.plan(1)
+  t.plan(2)
 
   app.use((f, opts, cb) => {
     app.use((f, opts, cb) => {
@@ -190,28 +194,30 @@ test('await after - error handling, same tick cb err, nested', async (t) => {
     })
     cb()
   })
-  await app.after()
-  t.rejects(() => app.ready(), Error('kaboom'))
+
+  await t.rejects(app.after())
+  await t.rejects(app.ready(), Error('kaboom'))
 })
 
 test('await after - error handling, future tick cb err', async (t) => {
   const app = {}
   boot(app)
 
-  t.plan(1)
+  t.plan(2)
 
   app.use((f, opts, cb) => {
     setImmediate(() => { cb(Error('kaboom')) })
   })
-  await app.after()
-  t.rejects(() => app.ready(), Error('kaboom'))
+
+  await t.rejects(app.after())
+  await t.rejects(app.ready(), Error('kaboom'))
 })
 
 test('await after - error handling, future tick cb err, nested', async (t) => {
   const app = {}
   boot(app)
 
-  t.plan(1)
+  t.plan(2)
 
   app.use((f, opts, cb) => {
     app.use((f, opts, cb) => {
@@ -219,8 +225,8 @@ test('await after - error handling, future tick cb err, nested', async (t) => {
     })
     cb()
   })
-  await app.after()
-  t.rejects(() => app.ready(), Error('kaboom'))
+  await t.rejects(app.after(), Error('kaboom'))
+  await t.rejects(app.ready(), Error('kaboom'))
 })
 
 test('await after complex scenario', async (t) => {
@@ -332,6 +338,8 @@ test('without autostart and with override', async (t) => {
 })
 
 test('stop processing after errors', async (t) => {
+  t.plan(2)
+
   const app = boot()
 
   try {

--- a/test/await-after.test.js
+++ b/test/await-after.test.js
@@ -134,7 +134,7 @@ test('await after - promise returning function plugins + promise chaining', asyn
   t.pass('reachable')
 })
 
-test('await after - error handling, async throw', { only: true }, async (t) => {
+test('await after - error handling, async throw', async (t) => {
   const app = {}
   boot(app)
 


### PR DESCRIPTION
In #95, I _thought_ I did this. Turns out I was missing a critical change, this is it.