### PR TITLE
After override

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ The callback changes basing on the parameters your are giving:
 1. If no parameter is given to the callback and there is an error, that error will be passed to the next error handler.
 2. If one parameter is given to the callback, that parameter will be the `error` object.
 3. If two parameters are given to the callback, the first will be the `error` object, the second will be the `done` callback.
-4. If three parameters are given to the callback, the first will be the `error` object, the second will be the top level `context` unless you have specified both server and override, in that case the `context` will be what the override returns, and the third the `done` callback.
+4. If three parameters are given to the callback, the first will be the `error` object, the second will be the top level `context` and the third the `done` callback.
 
 In the "no parameter" and "one parameter" variants, the callback can also
 return a `Promise`.

--- a/boot.js
+++ b/boot.js
@@ -260,7 +260,8 @@ Boot.prototype.after = function (func) {
     return this._loadRegistered()
   }
 
-  this._addPlugin(_after.bind(this), {}, true)
+  const afterFunctionCountArgs = (func.length + (func.constructor.name === 'AsyncFunction' ? 1 : 0)) || 3
+  this._addPlugin(_after.bind(this), {}, afterFunctionCountArgs)
 
   function _after (s, opts, done) {
     callWithCbOrNextTick.call(this, func, done)

--- a/boot.js
+++ b/boot.js
@@ -138,7 +138,7 @@ function Boot (server, opts, done) {
   }
 
   this._doStart = null
-  this._root = new Plugin(this, root.bind(this), opts, noop, 0)
+  this._root = new Plugin(this, root.bind(this), opts, false, 0)
   this._root.once('start', (serverName, funcName, time) => {
     const nodeId = this.pluginTree.start(null, funcName, time)
     this._root.once('loaded', (serverName, funcName, time) => {
@@ -260,8 +260,7 @@ Boot.prototype.after = function (func) {
     return this._loadRegistered()
   }
 
-  const afterFunctionCountArgs = (func.length + (func.constructor.name === 'AsyncFunction' ? 1 : 0)) || true
-  this._addPlugin(_after.bind(this), {}, afterFunctionCountArgs)
+  this._addPlugin(_after.bind(this), {}, true)
 
   function _after (s, opts, done) {
     callWithCbOrNextTick.call(this, func, done)

--- a/boot.js
+++ b/boot.js
@@ -260,7 +260,7 @@ Boot.prototype.after = function (func) {
     return this._loadRegistered()
   }
 
-  const afterFunctionCountArgs = (func.length + (func.constructor.name === 'AsyncFunction' ? 1 : 0)) || 3
+  const afterFunctionCountArgs = (func.length + (func.constructor.name === 'AsyncFunction' ? 1 : 0)) || true
   this._addPlugin(_after.bind(this), {}, afterFunctionCountArgs)
 
   function _after (s, opts, done) {

--- a/plugin.js
+++ b/plugin.js
@@ -142,10 +142,7 @@ Plugin.prototype.loadedSoFar = function () {
   }
 
   const setup = () => {
-    console.log('.............', this.server)
     this.server.after((err, cb) => {
-      console.log('.............')
-
       this._error = err
       this.q.pause()
       debug('resolving promise', this.name)

--- a/plugin.js
+++ b/plugin.js
@@ -74,7 +74,9 @@ Plugin.prototype.exec = function (server, cb) {
   }
 
   try {
-    this.server = this.parent.override(server, func, this.opts)
+    if (!this.isAfter || this.isAfter === 3) {
+      this.server = this.parent.override(server, func, this.opts)
+    }
   } catch (err) {
     debug('override errored', name)
     return cb(err)
@@ -140,7 +142,10 @@ Plugin.prototype.loadedSoFar = function () {
   }
 
   const setup = () => {
+    console.log('.............', this.server)
     this.server.after((err, cb) => {
+      console.log('.............')
+
       this._error = err
       this.q.pause()
       debug('resolving promise', this.name)

--- a/test/await-after.test.js
+++ b/test/await-after.test.js
@@ -331,7 +331,7 @@ test('without autostart and with override', async (t) => {
   await app.after()
 
   await app.use(async (app) => {
-    t.is(app.count, 5) // 5 because there are 2 after()
+    t.is(app.count, 3)
   })
 
   await app.ready()

--- a/test/override.test.js
+++ b/test/override.test.js
@@ -291,3 +291,52 @@ test('override can receive options function', (t) => {
     cb()
   }, p => ({ hello: p.bar }))
 })
+
+test('after trigger override', t => {
+  t.plan(8)
+
+  const server = { count: 0 }
+  const app = boot(server)
+
+  let overrideCalls = 0
+  app.override = function (s, fn, opts) {
+    overrideCalls++
+    const res = Object.create(s)
+    res.count = res.count + 1
+    return res
+  }
+
+  app
+    .use(function first (s, opts, cb) {
+      t.equals(s.count, 1, 'asd')
+      cb()
+    })
+    .after(function () {
+      t.equals(overrideCalls, 1, 'after with 0 parameter should not trigger override')
+    })
+    .after(function (err) {
+      if (err) throw err
+      t.equals(overrideCalls, 1, 'after with 1 parameter should not trigger override')
+    })
+    .after(function (err, done) {
+      if (err) throw err
+      t.equals(overrideCalls, 1, 'after with 2 parameters should not trigger override')
+      done()
+    })
+    .after(function (err, context, done) {
+      if (err) throw err
+      t.equals(overrideCalls, 2, 'after with 3 parameters should trigger override')
+      done()
+    })
+    .after(async function () {
+      t.equals(overrideCalls, 2, 'async after with 0 parameter should not trigger override')
+    })
+    .after(async function (err) {
+      if (err) throw err
+      t.equals(overrideCalls, 2, 'async after with 1 parameter should not trigger override')
+    })
+    .after(async function (err, context) {
+      if (err) throw err
+      t.equals(overrideCalls, 3, 'async after with 2 parameters should trigger override')
+    })
+})

--- a/test/override.test.js
+++ b/test/override.test.js
@@ -308,7 +308,7 @@ test('after trigger override', t => {
 
   app
     .use(function first (s, opts, cb) {
-      t.equals(s.count, 1, 'asd')
+      t.equals(s.count, 1, 'should trigger override')
       cb()
     })
     .after(function () {

--- a/test/override.test.js
+++ b/test/override.test.js
@@ -325,18 +325,18 @@ test('after trigger override', t => {
     })
     .after(function (err, context, done) {
       if (err) throw err
-      t.equals(overrideCalls, 2, 'after with 3 parameters should trigger override')
+      t.equals(overrideCalls, 1, 'after with 3 parameters should not trigger override')
       done()
     })
     .after(async function () {
-      t.equals(overrideCalls, 2, 'async after with 0 parameter should not trigger override')
+      t.equals(overrideCalls, 1, 'async after with 0 parameter should not trigger override')
     })
     .after(async function (err) {
       if (err) throw err
-      t.equals(overrideCalls, 2, 'async after with 1 parameter should not trigger override')
+      t.equals(overrideCalls, 1, 'async after with 1 parameter should not trigger override')
     })
     .after(async function (err, context) {
       if (err) throw err
-      t.equals(overrideCalls, 3, 'async after with 2 parameters should trigger override')
+      t.equals(overrideCalls, 1, 'async after with 2 parameters should not trigger override')
     })
 })


### PR DESCRIPTION
I lied 😅
My snippet didn't check the all the after's functions were wrapped in a function that had always 3 params.

Now the flow that calls `.after()` without any parameter doesn't work.. still working on it

Fixes #101 